### PR TITLE
issue #24

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sdk-components-ng"]
-	path = sdk-components-ng
-	url = git@github.com:senzingiris/sdk-components-ng.git


### PR DESCRIPTION
removed .gitmodules file. strangely I checked the .gitignore and the file was in the list, as well as the subrepo not being present in the .git/config file. Normally git does not checkout subrepo's unless explicitly told to do so, docker automated builds are deviating from that behavior for some reason.