### PR TITLE
docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,9 @@ RUN npm install --silent -g @angular/cli@7.3.9
 # add app
 COPY . /app
 
+# build app
+RUN npm run build:docker
+
 # start app
 ENTRYPOINT [ "npm", "run" ]
 CMD ["start:docker"]


### PR DESCRIPTION
runs the `npm run build:docker` during image build so that it's available by default startup.