### PR TITLE
use api server version env var OR fallback to 1.8.3 #108

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
 
   senzing-api-server:
-    image: senzing/senzing-api-server
+    image: senzing/senzing-api-server:${SENZING_API_SERVER_VERSION:-1.8.3}
     container_name: senzing-api-server
     command:
       - -httpPort

--- a/docker-stack-ssl-basicauth.yml
+++ b/docker-stack-ssl-basicauth.yml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
 
   senzing-api-server:
-    image: senzing/senzing-api-server
+    image: senzing/senzing-api-server:${SENZING_API_SERVER_VERSION:-1.8.3}
     command:
       - -httpPort
       - "8080"

--- a/docker-stack-ssl.yml
+++ b/docker-stack-ssl.yml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
 
   senzing-api-server:
-    image: senzing/senzing-api-server
+    image: senzing/senzing-api-server:${SENZING_API_SERVER_VERSION:-1.8.3}
     command:
       - -httpPort
       - "8080"

--- a/docker-stack.yml
+++ b/docker-stack.yml
@@ -2,7 +2,7 @@ version: '3.3'
 services:
 
   senzing-api-server:
-    image: senzing/senzing-api-server
+    image: senzing/senzing-api-server:${SENZING_API_SERVER_VERSION:-1.8.3}
     command:
       - -httpPort
       - "8080"


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

#108 

## Why was change needed

prevent possible breakage when using the compose examples against pre-release 2.0.0 api server.
