### PR TITLE
Virtual Directory Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,17 +6,27 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2,2.2.3] - 2021-04-07
+
+- support for virtual directories
+- support for AWS Cloud Formation. 
+
+relevant tickets: #147
+
 ## [2.2.1] - 2021-02-01
+
 - updated @senzing/sdk-graph-components to 2.1.3
 - updated @senzing/sdk-components-ng to 2.2.1
 - fixed bug where entity detail would not render when entity had 0 relationships.
 
 ## [2.2.0] - 2021-01-20
+
 - updated senzing libs to 2.2.0
 - bug in route resolver to only accept numbers for record paths fixed
 - Select Identifiers in Search Form feature added.
 
 ## [2.1.2] - 2020-12-20
+
 - updated senzing libs to 2.2.0
 - bug in route resolver to only accept numbers for record paths fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG BASE_IMAGE=node:12.2.0
 FROM ${BASE_IMAGE}
 
-ENV REFRESHED_AT=2021-1-28
+ENV REFRESHED_AT=2021-04-07
 
 LABEL Name="senzing/entity-search-web-app" \
       Maintainer="support@senzing.com" \
-      Version="2.2.2"
+      Version="2.2.3"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/entity-search-web-app",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "scripts": {
     "ng": "ng",
     "start": "npm run start:with:auth",

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -275,7 +275,12 @@ function createAuthConfigFromInput() {
       retConfig = retConfig !== undefined ? retConfig : {};
       retConfig.hostname = authOpts.authServerHostName;
     }
-
+  // _virtualDir is assigned at the very beginning
+  // and is both env and cmd
+  if(_virtualDir && _virtualDir !== '' && _virtualDir !== '/') {
+    retConfig = retConfig !== undefined ? retConfig : {};
+    retConfig.virtualPath = _virtualDir;
+  }
   // -------------------- end CMD LINE ARGS import -----------
 
   //console.log('AUTH TEMPLATE: ', authTemplate, fs.existsSync(authTemplate));
@@ -360,7 +365,7 @@ function getProxyServerOptionsFromInput() {
   let retOpts = {
     authServerHostName: "localhost",
     authServerPortNumber: 8080,
-    logLevel: "debug",
+    logLevel: "error",
     apiServerUrl: "",
     adminAuthPath: "http://localhost:8080",
     jwtPathRewrite: "/jwt",

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -282,6 +282,7 @@ function getWebServerOptionsFromInput() {
   let retOpts = {
     port: 4200,
     hostname: 'localhost',
+    path: '/',
     apiPath: '/api',
     authPath: 'http://localhost:8080',
     authMode: 'JWT',
@@ -299,6 +300,7 @@ function getWebServerOptionsFromInput() {
     retOpts.authPath      = env.SENZING_WEB_SERVER_AUTH_PATH ?        env.SENZING_WEB_SERVER_AUTH_PATH        : retOpts.authPath;
     retOpts.authMode      = env.SENZING_WEB_SERVER_ADMIN_AUTH_MODE ?  env.SENZING_WEB_SERVER_ADMIN_AUTH_MODE  : retOpts.authMode;
     retOpts.apiServerUrl  = env.SENZING_API_SERVER_URL ?              env.SENZING_API_SERVER_URL              : retOpts.apiServerUrl;
+    retOpts.path          = env.SENZING_WEB_SERVER_VIRTUAL_PATH ?     env.SENZING_WEB_SERVER_VIRTUAL_PATH     : retOpts.path;
     if(env.SENZING_WEB_SERVER_SSL_CERT_PATH) {
       retOpts.ssl.certPath = env.SENZING_WEB_SERVER_SSL_CERT_PATH;
     }
@@ -319,6 +321,7 @@ function getWebServerOptionsFromInput() {
     retOpts.authPath      = cmdLineOpts.webServerAuthPath ?     cmdLineOpts.webServerAuthPath     : retOpts.authPath;
     retOpts.authMode      = cmdLineOpts.webServerAuthMode ?     cmdLineOpts.webServerAuthMode     : retOpts.authMode;
     retOpts.apiServerUrl  = cmdLineOpts.webServerApiServerUrl ? cmdLineOpts.webServerApiServerUrl : retOpts.apiServerUrl;
+    retOpts.path          = cmdLineOpts.virtualPath ?           cmdLineOpts.virtualPath           : retOpts.path;
     if(retOpts.sslCertPath) {
       retOpts.ssl = retOpts.ssl ? retOpts.ssl : {};
       retOpts.ssl.certPath  = retOpts.sslCertPath;

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -146,26 +146,31 @@ function createCspConfigFromInput() {
 function createAuthConfigFromInput() {
   // return value
   let retConfig = undefined;
+  // grab env vars
+  let env = process.env;
+
+  // check for virtual directory
+  let cmdLineOpts = getCommandLineArgsAsJSON();
+  let _virtualDir = (env.SENZING_WEB_SERVER_VIRTUAL_PATH) ? env.SENZING_WEB_SERVER_VIRTUAL_PATH : '';
+  _virtualDir     = (cmdLineOpts && cmdLineOpts.virtualPath) ? cmdLineOpts.virtualPath : _virtualDir;
 
   // -------------------- start ENV vars import ------------------
-    // grab env vars
-    let env = process.env;
     if(env.SENZING_WEB_SERVER_ADMIN_AUTH_MODE) {
       retConfig = retConfig !== undefined ? retConfig : {};
       retConfig.admin = {};
       if(env.SENZING_WEB_SERVER_ADMIN_AUTH_MODE === 'JWT'){
         retConfig.admin = {
           "mode": "JWT",
-          "checkUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS ? env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS : "/admin/auth/jwt/status",
+          "checkUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS ? env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS : _virtualDir+"/admin/auth/jwt/status",
           "redirectOnFailure": true,
-          "loginUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT : "/admin/login"
+          "loginUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT : _virtualDir+"/admin/login"
         }
       } else if(env.SENZING_WEB_SERVER_ADMIN_AUTH_MODE === 'SSO') {
         retConfig.admin = {
           "mode": "SSO",
-          "checkUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS ? env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS : "/admin/auth/sso/status",
+          "checkUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS ? env.SENZING_WEB_SERVER_ADMIN_AUTH_STATUS : _virtualDir+"/admin/auth/sso/status",
           "redirectOnFailure": true,
-          "loginUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT : "/admin/login"
+          "loginUrl": env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_ADMIN_AUTH_REDIRECT : _virtualDir+"/admin/login"
         }
       }
     }
@@ -175,16 +180,16 @@ function createAuthConfigFromInput() {
       if(SENZING_WEB_SERVER_OPERATOR_AUTH_MODE === 'JWT'){
         retConfig.operator = {
           "mode": "JWT",
-          "checkUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS : "/auth/jwt/status",
+          "checkUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS : _virtualDir+"/auth/jwt/status",
           "redirectOnFailure": true,
-          "loginUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT : "/login"
+          "loginUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT : _virtualDir+"/login"
         }
       } else if(env.SENZING_WEB_SERVER_OPERATOR_AUTH_MODE === 'SSO') {
         retConfig.operator = {
           "mode": "SSO",
-          "checkUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS : "/auth/sso/status",
+          "checkUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_STATUS : _virtualDir+"/auth/sso/status",
           "redirectOnFailure": true,
-          "loginUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT : "/login"
+          "loginUrl": env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT ? env.SENZING_WEB_SERVER_OPERATOR_AUTH_REDIRECT : _virtualDir+"/login"
         }
       }
   }
@@ -230,16 +235,16 @@ function createAuthConfigFromInput() {
       if(authOpts.adminAuthMode === 'JWT') {
         retConfig.admin = {
           "mode": "JWT",
-          "checkUrl": authOpts.adminAuthStatusUrl ? authOpts.adminAuthStatusUrl : "/admin/auth/jwt/status",
+          "checkUrl": authOpts.adminAuthStatusUrl ? authOpts.adminAuthStatusUrl : _virtualDir+"/admin/auth/jwt/status",
           "redirectOnFailure": true,
-          "loginUrl": authOpts.adminAuthRedirectUrl ? authOpts.adminAuthRedirectUrl : "/admin/login"
+          "loginUrl": authOpts.adminAuthRedirectUrl ? authOpts.adminAuthRedirectUrl : _virtualDir+"/admin/login"
         }
       } else if (authOpts.adminAuthMode === 'SSO') {
         retConfig.admin = {
           "mode": "SSO",
-          "checkUrl": authOpts.adminAuthStatusUrl ? authOpts.adminAuthStatusUrl : "/admin/auth/sso/status",
+          "checkUrl": authOpts.adminAuthStatusUrl ? authOpts.adminAuthStatusUrl : _virtualDir+"/admin/auth/sso/status",
           "redirectOnFailure": authOpts.adminAuthRedirectOnFailure ? authOpts.adminAuthRedirectOnFailure : true,
-          "loginUrl": authOpts.adminAuthRedirectUrl ? authOpts.adminAuthRedirectUrl : "/admin/login"
+          "loginUrl": authOpts.adminAuthRedirectUrl ? authOpts.adminAuthRedirectUrl : _virtualDir+"/admin/login"
         }
       }
     }
@@ -249,23 +254,25 @@ function createAuthConfigFromInput() {
       if(authOpts.operatorAuthMode === 'JWT') {
         retConfig.operator = {
           "mode": "JWT",
-          "checkUrl": authOpts.operatorAuthStatusUrl ? authOpts.operatorAuthStatusUrl : "/auth/jwt/status",
+          "checkUrl": authOpts.operatorAuthStatusUrl ? authOpts.operatorAuthStatusUrl : _virtualDir+"/auth/jwt/status",
           "redirectOnFailure": true,
-          "loginUrl": authOpts.operatorAuthRedirectUrl ? authOpts.operatorAuthRedirectUrl : "/login"
+          "loginUrl": authOpts.operatorAuthRedirectUrl ? authOpts.operatorAuthRedirectUrl : _virtualDir+"/login"
         }
       } else if (authOpts.adminAuthMode === 'SSO') {
         retConfig.operator = {
           "mode": "SSO",
-          "checkUrl": authOpts.operatorAuthStatusUrl ? authOpts.operatorAuthStatusUrl : "/auth/sso/status",
+          "checkUrl": authOpts.operatorAuthStatusUrl ? authOpts.operatorAuthStatusUrl : _virtualDir+"/auth/sso/status",
           "redirectOnFailure": true,
-          "loginUrl": authOpts.operatorAuthRedirectUrl ? authOpts.operatorAuthRedirectUrl : "/login"
+          "loginUrl": authOpts.operatorAuthRedirectUrl ? authOpts.operatorAuthRedirectUrl : _virtualDir+"/login"
         }
       }
     }
     if(authOpts && authOpts !== undefined && authOpts.authServerPortNumber && authOpts.authServerPortNumber !== undefined) {
+      retConfig = retConfig !== undefined ? retConfig : {};
       retConfig.port = authOpts.authServerPortNumber;
     }
     if(authOpts && authOpts !== undefined && authOpts.authServerHostName && authOpts.authServerHostName !== undefined) {
+      retConfig = retConfig !== undefined ? retConfig : {};
       retConfig.hostname = authOpts.authServerHostName;
     }
 
@@ -353,7 +360,7 @@ function getProxyServerOptionsFromInput() {
   let retOpts = {
     authServerHostName: "localhost",
     authServerPortNumber: 8080,
-    logLevel: "error",
+    logLevel: "debug",
     apiServerUrl: "",
     adminAuthPath: "http://localhost:8080",
     jwtPathRewrite: "/jwt",
@@ -441,8 +448,10 @@ function getProxyServerOptionsFromInput() {
 }
 
 function createProxyConfigFromInput() {
-  let retConfig = undefined;
-  let proxyOpts = getProxyServerOptionsFromInput();
+  let retConfig     = undefined;
+  let proxyOpts     = getProxyServerOptionsFromInput();
+  let cmdLineOpts   = getCommandLineArgsAsJSON();
+
 
   if(env.SENZING_API_SERVER_URL) {
     retConfig = retConfig !== undefined ? retConfig : {};
@@ -456,9 +465,44 @@ function createProxyConfigFromInput() {
     }
   }
 
+  let _virtualDir = (env.SENZING_WEB_SERVER_VIRTUAL_PATH) ? env.SENZING_WEB_SERVER_VIRTUAL_PATH : '/';
+  _virtualDir     = (cmdLineOpts && cmdLineOpts.virtualPath) ? cmdLineOpts.virtualPath : _virtualDir;
+
+  let appendBasePathToKeys = (obj) => {
+    if(_virtualDir !== '/') {
+      // re-key object
+      let _retObj = {};
+      for(let pathKey in obj) {
+        let newKey = !pathKey.startsWith('/api') ? (_virtualDir + pathKey) : pathKey;
+        let newVal = obj[pathKey];
+        if(newVal && newVal.pathRewrite) {
+          // check pathRewrite for vdir pathing
+          let _pathRewriteObj = {};
+          console.log('');
+          for(let rewriteKey in newVal.pathRewrite) {
+            if(rewriteKey && rewriteKey.substring && rewriteKey.indexOf('^/') === 0) {
+              // append virtual dir to rewrite
+              _pathRewriteObj[ ('^'+ _virtualDir + rewriteKey.substring(1) ) ] = newVal.pathRewrite[ rewriteKey ];
+            } else {
+              // just return same value
+              _pathRewriteObj[ rewriteKey ] = newVal.pathRewrite[ rewriteKey ];
+            }
+          }
+          // update rewrite with any modifications
+          newVal.pathRewrite = _pathRewriteObj;
+        }
+        _retObj[newKey] = newVal;
+      }
+      return _retObj;
+    } else {
+      // just return object
+      return obj;
+    }
+  }
+
   if(env.SENZING_WEB_SERVER_ADMIN_AUTH_PATH) {
     retConfig = retConfig !== undefined ? retConfig : {};
-    let mergeObj = {
+    let mergeObj = appendBasePathToKeys({
       "/admin/auth/jwt/*": {
         "target": env.SENZING_WEB_SERVER_ADMIN_AUTH_PATH,
         "secure": true,
@@ -508,7 +552,7 @@ function createProxyConfigFromInput() {
           "^/cors/test": ""
         }
       }
-    }
+    });
     retConfig = Object.assign(retConfig, mergeObj);
   }
   // -------------------- start CMD LINE ARGS import -----------
@@ -526,7 +570,7 @@ function createProxyConfigFromInput() {
     }
     if(proxyOpts.adminAuthPath && proxyOpts.adminAuthPath !== undefined) {
       retConfig = retConfig !== undefined ? retConfig : {};
-      let mergeObj = {
+      let mergeObj = appendBasePathToKeys({
         "/admin/auth/jwt/*": {
           "target": proxyOpts.adminAuthPath,
           "secure": true,
@@ -576,7 +620,7 @@ function createProxyConfigFromInput() {
             "^/cors/test": ""
           }
         }
-      }
+      });
       retConfig = Object.assign(retConfig, mergeObj);
     }
   // -------------------- end CMD LINE ARGS import -----------

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -6,11 +6,11 @@ class inMemoryConfig {
   webConfiguration = {
     port: 8080,
     hostname: 'senzing-webapp',
+    path: '/',
     apiPath: '/api',
     authPath: 'http://senzing-webapp:8080',
     authMode: 'JWT',
     webServerUrl: 'http://senzing-webapp:8080',
-    webServerRootPath: '/',
     apiServerUrl: 'http://senzing-api-server:8080',
     ssl: {
       certPath: "/run/secrets/server.cert",

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -94,6 +94,9 @@ class inMemoryConfig {
         if(value.auth.port && value.auth.port !== undefined) {
           this.authConfiguration.port = value.auth.port;
         }
+        if(value.auth.virtualPath && value.auth.virtualPath !== undefined) {
+          this.authConfiguration.virtualPath = value.auth.virtualPath;
+        }
         if(value.auth.admin) {
           this.authConfiguration.admin = {};
           if(value.auth.admin.mode === 'JWT') {

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -10,6 +10,7 @@ class inMemoryConfig {
     authPath: 'http://senzing-webapp:8080',
     authMode: 'JWT',
     webServerUrl: 'http://senzing-webapp:8080',
+    webServerRootPath: '/',
     apiServerUrl: 'http://senzing-api-server:8080',
     ssl: {
       certPath: "/run/secrets/server.cert",

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -29,6 +29,7 @@ var corsOptions   = runtimeOptions.config.cors;
 var cspOptions    = runtimeOptions.config.csp;
 // proxy config
 var proxyOptions  = runtimeOptions.config.proxy;
+
 // web server config
 let serverOptions = runtimeOptions.config.web;
 
@@ -110,8 +111,9 @@ if(proxyOptions) {
       res.end('proxy encountered an error.');
     }
     proxyTargetOptions.onError = onError;
-    //console.log('Proxy CFG: '+ proxyPath);
-    //console.log(proxyTargetOptions);
+    console.log('Proxy CFG: '+ proxyPath);
+    console.log(proxyTargetOptions);
+    console.log('');
     app.use(proxyPath, apiProxy(proxyTargetOptions));
   }
 } else {
@@ -123,8 +125,16 @@ let virtualDirs = [];
 let staticPath  = path.resolve(path.join(__dirname, '../../', 'dist/entity-search-web-app'));
 let webCompPath = path.resolve(path.join(__dirname, '../../', '/node_modules/@senzing/sdk-components-web/'));
 app.use('/node_modules/@senzing/sdk-components-web', express.static(webCompPath));
-// app.use('/', express.static(staticPath));
-app.use(runtimeOptions.config.web.path, express.static(staticPath));
+app.use('/', express.static(staticPath));
+// serve static files from virtual directory if specified
+if(runtimeOptions.config && 
+  runtimeOptions.config.web && 
+  runtimeOptions.config.web.path) {
+    app.use(runtimeOptions.config.web.path, express.static(staticPath));
+    console.log('virtual directory', runtimeOptions.config.web.path);
+} else {
+  console.log('no virtual directory', runtimeOptions.config.web);
+}
 
 //console.log('\n\n STATIC PATH: '+staticPath,'\n');
 
@@ -140,13 +150,19 @@ const authRes = (req, res, next) => {
 };
 
 if(authOptions && authOptions !== undefined) {
-  app.get('/conf/auth', (req, res, next) => {
+  let _authBasePath = '';
+  if(runtimeOptions.config && 
+    runtimeOptions.config.web && 
+    runtimeOptions.config.web.path && runtimeOptions.config.web.path !== '/') {
+      _authBasePath = runtimeOptions.config.web.path;
+  }
+  app.get(_authBasePath+'/conf/auth', (req, res, next) => {
     res.status(200).json( authOptions );
   });
-  app.get('/conf/auth/admin', (req, res, next) => {
+  app.get(_authBasePath+'/conf/auth/admin', (req, res, next) => {
     res.status(200).json( authOptions.admin );
   });
-  app.get('/conf/auth/operator', (req, res, next) => {
+  app.get(_authBasePath+'/conf/auth/operator', (req, res, next) => {
     res.status(200).json( authOptions.operator );
   });
 
@@ -163,8 +179,8 @@ if(authOptions && authOptions !== undefined) {
     };
     // dunno if this should be a reverse proxy req or not
     // especially if the SSO uses cookies etc
-    app.get('/sso/admin/status', ssoResForceTrue);
-    app.get('/sso/admin/login', (req, res, next) => {
+    app.get(_authBasePath+'/sso/admin/status', ssoResForceTrue);
+    app.get(_authBasePath+'/sso/admin/login', (req, res, next) => {
       res.sendFile(path.resolve(path.join(__dirname,'../../', '/auth/sso-login.html')));
     });
     //STARTUP_MSG = STARTUP_MSG + '\n'+'';
@@ -201,24 +217,24 @@ if(authOptions && authOptions !== undefined) {
     app.get('/jwt/admin/login', jwtResForceTrue);
     */
 
-    app.post('/jwt/admin/status', auth.auth.bind(auth), jwtRes);
-    app.post('/jwt/admin/login', auth.login.bind(auth));
-    app.get('/jwt/admin/status', auth.auth.bind(auth), jwtRes);
-    app.get('/jwt/admin/login', auth.auth.bind(auth), jwtRes);
+    app.post(_authBasePath+'/jwt/admin/status', auth.auth.bind(auth), jwtRes);
+    app.post(_authBasePath+'/jwt/admin/login', auth.login.bind(auth));
+    app.get(_authBasePath+'/jwt/admin/status', auth.auth.bind(auth), jwtRes);
+    app.get(_authBasePath+'/jwt/admin/login', auth.auth.bind(auth), jwtRes);
 
     /** operator endpoints */
     if(authOptions.operator && authOptions.operator.mode === 'JWT') {
       // token auth for operators
-      app.post('/jwt/status', auth.auth.bind(adminAuth), jwtRes);
-      app.post('/jwt/login', auth.login.bind(adminAuth));
-      app.get('/jwt/status', auth.auth.bind(adminAuth), jwtRes);
-      app.get('/jwt/login', auth.auth.bind(adminAuth), jwtRes);
+      app.post(_authBasePath+'/jwt/status', auth.auth.bind(adminAuth), jwtRes);
+      app.post(_authBasePath+'/jwt/login', auth.login.bind(adminAuth));
+      app.get(_authBasePath+'/jwt/status', auth.auth.bind(adminAuth), jwtRes);
+      app.get(_authBasePath+'/jwt/login', auth.auth.bind(adminAuth), jwtRes);
     } else {
       // always return true for operators
-      app.post('/jwt/status', jwtResForceTrue);
-      app.post('/jwt/login', jwtResForceTrue);
-      app.get('/jwt/status', jwtResForceTrue);
-      app.get('/jwt/login', jwtResForceTrue);
+      app.post(_authBasePath+'/jwt/status', jwtResForceTrue);
+      app.post(_authBasePath+'/jwt/login', jwtResForceTrue);
+      app.get(_authBasePath+'/jwt/status', jwtResForceTrue);
+      app.get(_authBasePath+'/jwt/login', jwtResForceTrue);
     }
 
     STARTUP_MSG = STARTUP_MSG + '\n'+'';
@@ -265,7 +281,12 @@ if(authOptions && authOptions !== undefined) {
 // SPA page
 let VIEW_VARIABLES = {
   "VIEW_PAGE_TITLE":"Entity Search",
-  "VIEW_BASEHREF": (runtimeOptions.config.web.path && runtimeOptions.config.web.path.substring((runtimeOptions.config.web.path.length - 1)) !== '/') ? (runtimeOptions.config.web.path + '/') : runtimeOptions.config.web.path,
+  "VIEW_BASEHREF": (
+    runtimeOptions.config && 
+    runtimeOptions.config.web && 
+    runtimeOptions.config.web.path && 
+    runtimeOptions.config.web.path.substring((runtimeOptions.config.web.path.length - 1)) !== '/'
+  ) ? (runtimeOptions.config.web.path + '/') : runtimeOptions.config.web.path,
   "VIEW_CSP_DIRECTIVES":""
 }
 if(cspOptions && cspOptions.directives) {
@@ -286,27 +307,6 @@ if(cspOptions && cspOptions.directives) {
 app.set('views', path.resolve(path.join(__dirname, '..'+path.sep, '..'+path.sep, 'dist/entity-search-web-app')));
 app.set('view engine', 'pug');
 app.get('*', (req, res) => {
-  // we only want to take the first directory in the path 
-  // to limit injection attack surface
-  let virtualPath = req.originalUrl.substr(0, req.originalUrl.indexOf('/',1));
-  virtualPath = virtualPath.trim();
-  // now sanitize string (for control chars, path traversal etc)
-  // and hardcode first '/' char
-  virtualPath = sanitize(virtualPath.trim());
-  virtualPath = virtualPath !== '' ? '/'+ virtualPath : undefined;
-  if(virtualPath){
-    //VIEW_VARIABLES.VIEW_BASEHREF = virtualPath && virtualPath.substring && virtualPath.substring(virtualPath.length-1) !== '/' ? (virtualPath +'/') : virtualPath;
-    /*
-    //VIEW_VARIABLES.VIEW_BASEHREF = virtualPath;
-    if(virtualDirs && virtualDirs.indexOf && virtualDirs.indexOf(virtualPath) < 0) {
-      // add virtual dir to static asset mount point
-      virtualDirs.push(virtualPath); // keep a record of these
-      console.log(`Added "${virtualPath} to static assets mount paths (${virtualDirs.indexOf(VIEW_VARIABLES.VIEW_BASEHREF) < 0})"`, virtualDirs, staticPath);
-      //app.use(virtualPath, express.static(staticPath));
-      app.use('/app', express.static(staticPath));
-    };*/
-  }
-
   res.render('index', VIEW_VARIABLES);
 });
 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -123,7 +123,9 @@ let virtualDirs = [];
 let staticPath  = path.resolve(path.join(__dirname, '../../', 'dist/entity-search-web-app'));
 let webCompPath = path.resolve(path.join(__dirname, '../../', '/node_modules/@senzing/sdk-components-web/'));
 app.use('/node_modules/@senzing/sdk-components-web', express.static(webCompPath));
-app.use(express.static(staticPath));
+app.use('/', express.static(staticPath));
+app.use(runtimeOptions.config.web.path, express.static(staticPath));
+
 //console.log('\n\n STATIC PATH: '+staticPath,'\n');
 
 // admin auth tokens
@@ -263,7 +265,7 @@ if(authOptions && authOptions !== undefined) {
 // SPA page
 let VIEW_VARIABLES = {
   "VIEW_PAGE_TITLE":"Entity Search",
-  "VIEW_BASEHREF":"/",
+  "VIEW_BASEHREF": runtimeOptions.config.web.path,
   "VIEW_CSP_DIRECTIVES":""
 }
 if(cspOptions && cspOptions.directives) {
@@ -293,14 +295,18 @@ app.get('*', (req, res) => {
   virtualPath = sanitize(virtualPath.trim());
   virtualPath = virtualPath !== '' ? '/'+ virtualPath : undefined;
   if(virtualPath){
-    VIEW_VARIABLES.VIEW_BASEHREF = virtualPath
-    if(virtualDirs && virtualDirs.indexOf && virtualDirs.indexOf(VIEW_VARIABLES.VIEW_BASEHREF) < 0) {
+    VIEW_VARIABLES.VIEW_BASEHREF = virtualPath && virtualPath.substring && virtualPath.substring(virtualPath.length-1) !== '/' ? (virtualPath +'/') : virtualPath;
+    /*
+    //VIEW_VARIABLES.VIEW_BASEHREF = virtualPath;
+    if(virtualDirs && virtualDirs.indexOf && virtualDirs.indexOf(virtualPath) < 0) {
       // add virtual dir to static asset mount point
-      //console.log(`Added "${virtualPath} to static assets mount paths (${virtualDirs.indexOf(VIEW_VARIABLES.VIEW_BASEHREF) < 0})"`,virtualDirs);
-      virtualDirs.push(VIEW_VARIABLES.VIEW_BASEHREF); // keep a record of these
-      app.use(VIEW_VARIABLES.VIEW_BASEHREF, express.static(staticPath));
-    };
+      virtualDirs.push(virtualPath); // keep a record of these
+      console.log(`Added "${virtualPath} to static assets mount paths (${virtualDirs.indexOf(VIEW_VARIABLES.VIEW_BASEHREF) < 0})"`, virtualDirs, staticPath);
+      //app.use(virtualPath, express.static(staticPath));
+      app.use('/app', express.static(staticPath));
+    };*/
   }
+
   res.render('index', VIEW_VARIABLES);
 });
 
@@ -338,7 +344,7 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
       //STARTUP_MSG = 'WS Proxy Server started on port '+ (serverOptions.streamServerPort || 8255) +'. Forwarding to "'+ serverOptions.streamServerDestUrl +'"\n'+ STARTUP_MSG;
     } else {
       //STARTUP_MSG = STARTUP_MSG + '\n NO WS PROXY!!';
-      console.log('NO WS PROXY!!', serverOptions);
+      //console.log('NO WS PROXY!!', serverOptions);
       resolve();
     }
   }, (reason) => { 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -123,7 +123,7 @@ let virtualDirs = [];
 let staticPath  = path.resolve(path.join(__dirname, '../../', 'dist/entity-search-web-app'));
 let webCompPath = path.resolve(path.join(__dirname, '../../', '/node_modules/@senzing/sdk-components-web/'));
 app.use('/node_modules/@senzing/sdk-components-web', express.static(webCompPath));
-app.use('/', express.static(staticPath));
+// app.use('/', express.static(staticPath));
 app.use(runtimeOptions.config.web.path, express.static(staticPath));
 
 //console.log('\n\n STATIC PATH: '+staticPath,'\n');
@@ -265,7 +265,7 @@ if(authOptions && authOptions !== undefined) {
 // SPA page
 let VIEW_VARIABLES = {
   "VIEW_PAGE_TITLE":"Entity Search",
-  "VIEW_BASEHREF": runtimeOptions.config.web.path,
+  "VIEW_BASEHREF": (runtimeOptions.config.web.path && runtimeOptions.config.web.path.substring((runtimeOptions.config.web.path.length - 1)) !== '/') ? (runtimeOptions.config.web.path + '/') : runtimeOptions.config.web.path,
   "VIEW_CSP_DIRECTIVES":""
 }
 if(cspOptions && cspOptions.directives) {
@@ -295,7 +295,7 @@ app.get('*', (req, res) => {
   virtualPath = sanitize(virtualPath.trim());
   virtualPath = virtualPath !== '' ? '/'+ virtualPath : undefined;
   if(virtualPath){
-    VIEW_VARIABLES.VIEW_BASEHREF = virtualPath && virtualPath.substring && virtualPath.substring(virtualPath.length-1) !== '/' ? (virtualPath +'/') : virtualPath;
+    //VIEW_VARIABLES.VIEW_BASEHREF = virtualPath && virtualPath.substring && virtualPath.substring(virtualPath.length-1) !== '/' ? (virtualPath +'/') : virtualPath;
     /*
     //VIEW_VARIABLES.VIEW_BASEHREF = virtualPath;
     if(virtualDirs && virtualDirs.indexOf && virtualDirs.indexOf(virtualPath) < 0) {

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -111,9 +111,9 @@ if(proxyOptions) {
       res.end('proxy encountered an error.');
     }
     proxyTargetOptions.onError = onError;
-    console.log('Proxy CFG: '+ proxyPath);
-    console.log(proxyTargetOptions);
-    console.log('');
+    //console.log('Proxy CFG: '+ proxyPath);
+    //console.log(proxyTargetOptions);
+    //console.log('');
     app.use(proxyPath, apiProxy(proxyTargetOptions));
   }
 } else {
@@ -131,9 +131,9 @@ if(runtimeOptions.config &&
   runtimeOptions.config.web && 
   runtimeOptions.config.web.path) {
     app.use(runtimeOptions.config.web.path, express.static(staticPath));
-    console.log('virtual directory', runtimeOptions.config.web.path);
+    STARTUP_MSG = STARTUP_MSG + '\n'+`-- VIRTUAL DIRECTORY : ${runtimeOptions.config.web.path} --`;
 } else {
-  console.log('no virtual directory', runtimeOptions.config.web);
+  //console.log('no virtual directory', runtimeOptions.config.web);
 }
 
 //console.log('\n\n STATIC PATH: '+staticPath,'\n');
@@ -157,6 +157,12 @@ if(authOptions && authOptions !== undefined) {
       _authBasePath = runtimeOptions.config.web.path;
   }
   app.get(_authBasePath+'/conf/auth', (req, res, next) => {
+    res.status(200).json( authOptions );
+  });
+  // we need a wildcarded version due to 
+  // queries from virtual directory hosted apps
+  // and any number of SPA routes on top of that
+  app.get('*/conf/auth', (req, res, next) => {
     res.status(200).json( authOptions );
   });
   app.get(_authBasePath+'/conf/auth/admin', (req, res, next) => {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,6 @@
 /** core angular, material, and senzing modules */
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { NgModule, InjectionToken } from '@angular/core';
-import { APP_BASE_HREF } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from './material.module';
@@ -105,11 +104,7 @@ import { SzWebAppConfigService } from './services/config.service';
     UiService,
     PrefsManagerService,
     AboutInfoService,
-    Title,
-    {
-      provide: APP_BASE_HREF,
-      useValue: '/' + (window.location.pathname.split('/')[1] || '')
-    }
+    Title
   ],
   bootstrap: [ AppComponent ]
 })

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,7 @@
 /** core angular, material, and senzing modules */
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { NgModule, InjectionToken } from '@angular/core';
+import { APP_BASE_HREF } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { MaterialModule } from './material.module';
@@ -104,7 +105,11 @@ import { SzWebAppConfigService } from './services/config.service';
     UiService,
     PrefsManagerService,
     AboutInfoService,
-    Title
+    Title,
+    {
+      provide: APP_BASE_HREF,
+      useValue: '/' + (window.location.pathname.split('/')[1] || '')
+    }
   ],
   bootstrap: [ AppComponent ]
 })

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -207,7 +207,7 @@ export class AdminAuthService {
       tap( (resp: boolean) => {
         const _isChanged = (this.adminService.adminEnabled !== resp);
         this.adminService.adminEnabled = resp;
-        //console.info('AdminAuthService.pollForIsAdminEnabled: ', this.isAdminModeEnabled);
+        //console.info('AdminAuthService.checkServerInfo: ', this.isAdminModeEnabled, _isChanged);
         if( _isChanged ) { this.onAdminModeChange.next( this.adminService.adminEnabled ); }
       })
     );

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -38,6 +38,12 @@ export class AdminAuthService {
   public get authConfigLoaded(): boolean {
     return (this._authConfig && this._authConfig !== undefined) ? true : false;
   }
+  public get isOnVirtualPath(): boolean {
+    return this.virtualPath && this.virtualPath !== undefined ? true : false;
+  }
+  public get virtualPath(): string | undefined {
+    return this._authConfig && this._authConfig.virtualPath && this._authConfig.virtualPath !== '' && this._authConfig.virtualPath !== '/' && this._authConfig.virtualPath !== undefined ? this._authConfig.virtualPath : undefined;
+  }
 
   /** whether or not a user is granted admin rights */
   private _isAuthenticated: boolean = true;

--- a/src/app/services/ag.service.ts
+++ b/src/app/services/ag.service.ts
@@ -145,7 +145,7 @@ export class AuthGuardService implements CanActivate {
         } else {
           return this.adminAuth.checkServerInfo().pipe(
             tap((resi: boolean) => {
-              //console.warn('has admin enabled? ', resi);
+              console.warn('has admin enabled? ', resi);
               responseMap.adminEnabled = resi;
               //responses.push(resi);
             })
@@ -153,7 +153,7 @@ export class AuthGuardService implements CanActivate {
         }
       }),
       tap( (results: boolean) => {
-        //console.warn('!!RESULT!! ', responseMap, results);
+        console.warn('!!AUTH RESULT!! ', responseMap, results);
         if(!responseMap.adminEnabled) {
           this.router.navigate( ['admin', 'error', 'admin-mode-disabled'] );
         } else if(!responseMap.noAuth && !responseMap.sso && !responseMap.jwt) {

--- a/src/app/services/ag.service.ts
+++ b/src/app/services/ag.service.ts
@@ -28,7 +28,15 @@ export class AuthGuardService implements CanActivate {
       if( this.isUrlExternal(this.adminAuth.loginUrl) ) {
         this.router.navigate(['/admin/externalRedirect', { externalUrl: this.adminAuth.loginUrl }]);
       } else {
-        this.router.navigateByUrl(this.adminAuth.loginUrl);
+        let redirectUrl = this.adminAuth.loginUrl;
+        if(this.adminAuth && this.adminAuth.isOnVirtualPath && this.adminAuth.virtualPath) {
+          // strip virtual path from redirect url
+          // otherwise the angular router will "double-dip" on 
+          // the base-href and you will get two base-hrefs in the path
+          redirectUrl = redirectUrl.replace(this.adminAuth.virtualPath, '');
+        }
+        this.router.navigateByUrl(redirectUrl);
+        //this.router.navigateByUrl(this.adminAuth.loginUrl);
       }
     } else if(this.adminAuth.redirectOnFailure) {
       console.warn('REDIRECTING TO JWT LOGIN: ', this.adminAuth.loginUrl, this.isUrlExternal(this.adminAuth.loginUrl));
@@ -100,7 +108,15 @@ export class AuthGuardService implements CanActivate {
               if( this.isUrlExternal(authConf.admin.loginUrl) ) {
                 this.router.navigate(['/admin/externalRedirect', { externalUrl: this.adminAuth.loginUrl }]);
               } else {
-                this.router.navigateByUrl( authConf.admin.loginUrl );
+                // check to see if we need to strip base href
+                let redirectUrl = authConf.admin.loginUrl;
+                if(authConf && authConf.virtualPath && authConf.virtualPath !== '' && authConf.virtualPath !== '/') {
+                  // strip virtual path from redirect url
+                  // otherwise the angular router will "double-dip" on 
+                  // the base-href and you will get two base-hrefs in the path
+                  redirectUrl = redirectUrl.replace(authConf.virtualPath, '');
+                }
+                this.router.navigateByUrl( redirectUrl );
               }
               retReq = of(false);
             } else {
@@ -145,7 +161,6 @@ export class AuthGuardService implements CanActivate {
         } else {
           return this.adminAuth.checkServerInfo().pipe(
             tap((resi: boolean) => {
-              console.warn('has admin enabled? ', resi);
               responseMap.adminEnabled = resi;
               //responses.push(resi);
             })

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -53,6 +53,6 @@ export class SzWebAppConfigService {
     // config. we cant do this with static files
     // directly since container is immutable and
     // dont write to file system.
-    return this.http.get<AuthConfig>('/config/auth');
+    return this.http.get<AuthConfig>('/app/config/auth');
   }
 }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -9,6 +9,7 @@ import { HttpClient } from '@angular/common/http';
 export interface AuthConfig {
   hostname?: string;
   port?: number;
+  virtualPath?: string;
   admin: {
     mode: string | boolean;
     checkUrl?: string;
@@ -53,6 +54,6 @@ export class SzWebAppConfigService {
     // config. we cant do this with static files
     // directly since container is immutable and
     // dont write to file system.
-    return this.http.get<AuthConfig>('/app/config/auth');
+    return this.http.get<AuthConfig>('./config/auth');
   }
 }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves: #147 

## Why was change needed

to support virtual directory paths needed for AWS Cloud Formation

## What does change improve
The configuration can now be told to serve the application from a non-root directory by setting an env var or a cmd line switch via:

```
SENZING_WEB_SERVER_VIRTUAL_PATH: /app
```

and as a command line argument: `virtualPath="/app"`

You will also need to set the admin area's authentication path to include the virtual directory otherwise all auth conf checks will deny access to the /admin area. If running in a secured or gated configuration the `/app/admin` sections security can be turned off by setting `SENZING_WEB_SERVER_ADMIN_AUTH_MODE=NONE`

The relevant set of configuration variables would look like:
```
SENZING_WEB_SERVER_VIRTUAL_PATH: /app
SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251/app
SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
```