### PR TITLE
#163 added /config/api intf for api path modification for immutable c…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.4] - TBD
+
+- support for runtime configuration of API path that client connects to through env vars and cmdline switches. 
+
+relevant tickets: #163
+
 ## [2.2.2,2.2.3] - 2021-04-08
 
 - support for virtual directories

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 ARG BASE_IMAGE=node:12.2.0
 FROM ${BASE_IMAGE}
 
-ENV REFRESHED_AT=2021-04-07
+ENV REFRESHED_AT=2021-04-26
 
 LABEL Name="senzing/entity-search-web-app" \
       Maintainer="support@senzing.com" \
-      Version="2.2.3"
+      Version="2.2.4"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/entity-search-web-app",
-  "version": "2.2.3",
+  "version": "2.2.4",
   "scripts": {
     "ng": "ng",
     "start": "npm run start:with:auth",

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -446,12 +446,18 @@ function createProxyConfigFromInput() {
     retConfig = retConfig !== undefined ? retConfig : {};
     let _pathRewriteObj = {};
     let _apiVDir        = _virtualDir && _virtualDir !== '/' ? _virtualDir : '';
-    
-    webSrvrOpts.apiPath = webSrvrOpts && webSrvrOpts.apiPath ? webSrvrOpts.apiPath : '/api';
-    _pathRewriteObj["^"+ (_apiVDir + (webSrvrOpts.apiPath ? webSrvrOpts.apiPath : '/api')).replace("//","/") ]   = "";
-    //console.log('-- API SERVER PATH: '+ webSrvrOpts.apiPath +' --');
-    //console.log(_pathRewriteObj)
-    retConfig[ (_apiVDir + webSrvrOpts.apiPath +"/*").replace("//","/") ] = {
+    let _apiFullPath    = webSrvrOpts && webSrvrOpts.apiPath ? webSrvrOpts.apiPath : '/api';
+
+    // if apiPath unspecified AND virtualDir specified
+    // serve api requests from under virtual dir path
+    if(_apiFullPath === '/api' && _apiVDir !== '') {
+      _apiFullPath    = (_apiVDir + (_apiFullPath ? _apiFullPath : '/api')).replace("//","/");
+    } else {
+      _apiFullPath    = (_apiFullPath ? _apiFullPath : '/api').replace("//","/");
+    }
+    _pathRewriteObj["^"+ _apiFullPath ]   = "";
+
+    retConfig[ _apiFullPath ] = {
       "target": proxyOpts.apiServerUrl,
       "secure": true,
       "logLevel": proxyOpts.logLevel,

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -135,6 +135,22 @@ if(runtimeOptions.config &&
 } else {
   //console.log('no virtual directory', runtimeOptions.config.web);
 }
+// we need a wildcarded version due to 
+// queries from virtual directory hosted apps
+// and any number of SPA routes on top of that
+app.get('*/config/api', (req, res, next) => {
+  let _retObj = {};
+  if(runtimeOptions.config.web) {
+    if(runtimeOptions.config.web.apiPath) {
+      _retObj.basePath  = runtimeOptions.config.web.apiPath;
+    }
+    if(runtimeOptions.config.web.path && runtimeOptions.config.web.path !== '/') {
+      _retObj.basePath  = runtimeOptions.config.web.path + _retObj.basePath;
+      _retObj.basePath  = _retObj.basePath.replace("//","/");
+    }
+  }
+  res.status(200).json( _retObj );
+});
 
 //console.log('\n\n STATIC PATH: '+staticPath,'\n');
 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -144,7 +144,9 @@ app.get('*/config/api', (req, res, next) => {
     if(runtimeOptions.config.web.apiPath) {
       _retObj.basePath  = runtimeOptions.config.web.apiPath;
     }
-    if(runtimeOptions.config.web.path && runtimeOptions.config.web.path !== '/') {
+    // if "apiPath" set to default "/api" AND virtual dir specified
+    // serve "apiPath" under virtual dir instread of root level
+    if(runtimeOptions.config.web.path && runtimeOptions.config.web.path !== '/' && runtimeOptions.config.web.apiPath === '/api') {
       _retObj.basePath  = runtimeOptions.config.web.path + _retObj.basePath;
       _retObj.basePath  = _retObj.basePath.replace("//","/");
     }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -17,6 +17,7 @@ import { EntitySearchService } from './services/entity-search.service';
 import { SpinnerService } from './services/spinner.service';
 import { UiService } from './services/ui.service';
 import { PrefsManagerService } from './services/prefs-manager.service';
+import { SzWebAppConfigService } from './services/config.service';
 
  @Component({
   selector: 'app-root',
@@ -101,6 +102,7 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   constructor(
+    private configService: SzWebAppConfigService,
     private entitySearchService: EntitySearchService,
     private router: Router,
     private route: ActivatedRoute,
@@ -111,7 +113,8 @@ export class AppComponent implements OnInit, OnDestroy {
     public search: EntitySearchService,
     private prefsManager: PrefsManagerService
   ) {
-
+    // get "/config/api" for immutable api path configuration
+    this.configService.getRuntimeApiConfig();
   }
 
   ngOnInit() {

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -3,7 +3,7 @@ import { CanActivate, Router } from '@angular/router';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { Observable, of, from, interval, Subject } from 'rxjs';
 import { map, catchError, tap, switchMap, take } from 'rxjs/operators';
-import { SzConfigurationService, SzAdminService, SzServerInfo, SzBaseResponseMeta } from '@senzing/sdk-components-ng';
+import { SzRestConfigurationParameters, SzConfigurationService, SzAdminService, SzServerInfo, SzBaseResponseMeta } from '@senzing/sdk-components-ng';
 import { HttpClient } from '@angular/common/http';
 
 export interface AuthConfig {
@@ -33,16 +33,39 @@ export interface AuthConfig {
 })
 export class SzWebAppConfigService {
   private _authConfig: AuthConfig;
+  private _apiConfig: SzRestConfigurationParameters;
+
   public get authConfig(): AuthConfig {
     return this._authConfig;
   }
   public set authConfig(value: AuthConfig) {
     this._authConfig = value;
   }
-  private _onAuthConfigChange: Subject<AuthConfig> = new Subject<AuthConfig>();
-  public onAuthConfigChange = this._onAuthConfigChange.asObservable();
+  public get apiConfig(): SzRestConfigurationParameters {
+    return this._apiConfig;
+  }
+  public set apiConfig(value: SzRestConfigurationParameters) {
+    this._apiConfig = value;
+  }
+  private _onAuthConfigChange: Subject<AuthConfig>                    = new Subject<AuthConfig>();
+  public onAuthConfigChange                                           = this._onAuthConfigChange.asObservable();
+  private _onApiConfigChange: Subject<SzRestConfigurationParameters>  = new Subject<SzRestConfigurationParameters>();
+  public onApiConfigChange                                            = this._onApiConfigChange.asObservable();
 
-  constructor( private http: HttpClient ) {
+  constructor( 
+    private http: HttpClient,
+    private sdkConfigService: SzConfigurationService
+  ) {
+    this.getRuntimeApiConfig().pipe(
+      take(1)
+    ).subscribe((apiConf: SzRestConfigurationParameters) => {
+      //console.warn('SzWebAppConfigService.getRuntimeApiConfig: response', apiConf);
+      this._apiConfig = apiConf;
+      if(this._apiConfig.basePath !== this.sdkConfigService.basePath) {
+        this.sdkConfigService.basePath    = this._apiConfig.basePath;
+        //console.warn('SzWebAppConfigService.getRuntimeApiConfig: set SDK basePath', apiConf);
+      }
+    });
     this.getRuntimeAuthConfig().pipe(
       take(1)
     ).subscribe((authConf: AuthConfig) => {
@@ -53,7 +76,14 @@ export class SzWebAppConfigService {
     // reach out to webserver to get auth
     // config. we cant do this with static files
     // directly since container is immutable and
-    // dont write to file system.
+    // doesnt write to file system.
     return this.http.get<AuthConfig>('./config/auth');
+  }
+  public getRuntimeApiConfig(): Observable<SzRestConfigurationParameters> {
+    // reach out to webserver to get api
+    // config. we cant do this with static files
+    // directly since container is immutable and
+    // doesnt write to file system.
+    return this.http.get<SzRestConfigurationParameters>('./config/api');
   }
 }


### PR DESCRIPTION

# Pull request questions

## Which issue does this address

resolves #163 

## Why was change needed

To allow users to specify the local path(by default `/api`) that gets proxied to the api-rest-server without recompiling actual code.

## What does change improve

added /config/api intf for api path modification for immutable containers
