### PR TITLE
#165 fix for local dev api conf issue

### DIFF
--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,8 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
-import { ActivatedRouteSnapshot } from '@angular/router';
-import { Observable, of, from, interval, Subject } from 'rxjs';
-import { map, catchError, tap, switchMap, take } from 'rxjs/operators';
+import { Observable, of, Subject } from 'rxjs';
+import { catchError, take } from 'rxjs/operators';
 import { SzRestConfigurationParameters, SzConfigurationService, SzAdminService, SzServerInfo, SzBaseResponseMeta } from '@senzing/sdk-components-ng';
 import { HttpClient } from '@angular/common/http';
 
@@ -84,6 +82,13 @@ export class SzWebAppConfigService {
     // config. we cant do this with static files
     // directly since container is immutable and
     // doesnt write to file system.
-    return this.http.get<SzRestConfigurationParameters>('./config/api');
+    return this.http.get<SzRestConfigurationParameters>('./config/api').pipe(
+      catchError((err) => {
+        // return default payload for local developement when "/config/api" not available
+        return of({
+          basePath: "/api"
+        })
+      })
+    );
   }
 }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #165 

## Why was change needed

making the code dynamically pull the path that api calls should be made to(see #163 #164 ) borked local development when not using production/docker express server

## What does change improve

failed calls to `/config/api` (which don't exist when running angular development server) return a default payload/basepath of `/api`
