### PR TITLE
Issue192.awinters.1

### DIFF
--- a/run/utils.js
+++ b/run/utils.js
@@ -86,8 +86,29 @@ let getRootFromUrl = function(url) {
     return url;
 }
 
+let getPathFromUrl = function(url) {
+    if(!url) return;
+    if( url ) {
+        let path    = '';
+        if(url.indexOf && url.indexOf('://') > -1) {
+            let urlTokened = url.split('://');
+            let strPath  = urlTokened[1];
+            if(strPath.indexOf && strPath.indexOf('/') > -1) {
+                path = strPath.substring(strPath.indexOf('/'));
+            } else {
+                // no "/" in url
+            }
+        } else if(url.indexOf && url.indexOf('/') > -1) {
+            // no protocol, assume first "/" to end
+            path = url.substring(url.indexOf('/'));
+        }
+        return path;
+    }
+}
+
 module.exports = {
     "getHostnameFromUrl": getHostnameFromUrl,
+    "getPathFromUrl": getPathFromUrl,
     "getPortFromUrl": getPortFromUrl,
     "getProtocolFromUrl": getProtocolFromUrl,
     "getRootFromUrl": getRootFromUrl,

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -406,9 +406,9 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
         });
         wsProxy.on('upgrade', function (req, socket, head) {
           let oldUrl = req.url;
-          if(req.url && req.url.startsWith && req.url.startsWith( getPathFromUrl(streamClientUrl) ) && getPathFromUrl(streamClientUrl) !== '/') {
+          if(req.url && req.url.startsWith && req.url.startsWith( getPathFromUrl(serverOptions.streamClientUrl) ) && getPathFromUrl(serverOptions.streamClientUrl) !== '/') {
             // make sure we strip off that path
-            req.url = req.url.substring( getPathFromUrl(streamClientUrl).length );
+            req.url = req.url.substring( getPathFromUrl(serverOptions.streamClientUrl).length );
             if(proxyOptions.logLevel === 'debug') {
               console.log(`rewrote websocket conn path from "${oldUrl}" to "${req.url}"`);
             }

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -14,6 +14,7 @@ const fs = require('fs');
 const csp = require(`helmet-csp`);
 const winston = require(`winston`);
 const sanitize = require("sanitize-filename");
+const { getPathFromUrl } = require("../utils");
 
 // utils
 const AuthModule = require('../authserver/auth');
@@ -29,7 +30,8 @@ var corsOptions   = runtimeOptions.config.cors;
 // csp
 var cspOptions    = runtimeOptions.config.csp;
 // proxy config
-var proxyOptions  = runtimeOptions.config.proxy;
+var proxyConfig  = runtimeOptions.config.proxy;  // these are the actual path-rewrite/src/target collection objects
+var proxyOptions = (inMemoryConfigFromInputs).proxyServerOptions;  // runtime options used to generate some of the re-write objects etc
 
 // web server config
 let serverOptions = runtimeOptions.config.web;
@@ -105,11 +107,14 @@ if( serverOptions.authBasicJson ){
 }
 
 // set up proxy tunnels
-if(proxyOptions) {
+if(proxyConfig) {
   STARTUP_MSG = STARTUP_MSG + '\n'+'-- REVERSE PROXY PATHS SET UP --';
+  if(proxyOptions.logLevel === 'debug') {
+    STARTUP_MSG = STARTUP_MSG + '\n'+'-- PROXY LOG LEVEL: '+ proxyOptions.logLevel +' --';
+  }
 
-  for(proxyPath in proxyOptions){
-    let proxyTargetOptions = proxyOptions[proxyPath];
+  for(proxyPath in proxyConfig){
+    let proxyTargetOptions = proxyConfig[proxyPath];
     // add custom error handler to prevent XSS/Injection in to error response
     function onError(err, req, res) {
       res.writeHead(500, {
@@ -118,9 +123,9 @@ if(proxyOptions) {
       res.end('proxy encountered an error.');
     }
     proxyTargetOptions.onError = onError;
-    //console.log('Proxy CFG: '+ proxyPath);
-    //console.log(proxyTargetOptions);
-    //console.log('');
+    if(proxyOptions.logLevel === 'debug') {
+      STARTUP_MSG = STARTUP_MSG + '\n'+' ['+proxyPath+'] ~> '+ proxyTargetOptions.target +' ('+ JSON.stringify(proxyTargetOptions.pathRewrite) +')';
+    }
     app.use(proxyPath, apiProxy(proxyTargetOptions));
   }
 } else {
@@ -400,7 +405,18 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
           proxy.web(req, res);
         });
         wsProxy.on('upgrade', function (req, socket, head) {
-          req.url = (req.url && req.url.startsWith && req.url.startsWith(serverOptions.path) && serverOptions.path !== '/') ? req.url.substring(serverOptions.path.length) : req.url;
+          let oldUrl = req.url;
+          if(req.url && req.url.startsWith && req.url.startsWith( getPathFromUrl(streamClientUrl) ) && getPathFromUrl(streamClientUrl) !== '/') {
+            // make sure we strip off that path
+            req.url = req.url.substring( getPathFromUrl(streamClientUrl).length );
+            if(proxyOptions.logLevel === 'debug') {
+              console.log(`rewrote websocket conn path from "${oldUrl}" to "${req.url}"`);
+            }
+          } else if(req.url && req.url.startsWith && req.url.startsWith(serverOptions.path) && serverOptions.path !== '/') {
+            req.url = req.url.substring(serverOptions.path.length);
+          } else {
+            req.url = req.url;
+          }
           proxy.ws(req, socket, head);
         });
         wsProxy.listen(streamOptions.proxy.port || 8255, () => {

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -406,7 +406,7 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
         });
         wsProxy.on('upgrade', function (req, socket, head) {
           let oldUrl = req.url;
-          if(req.url && req.url.startsWith && req.url.startsWith( getPathFromUrl(serverOptions.streamClientUrl) ) && getPathFromUrl(serverOptions.streamClientUrl) !== '/') {
+          if(req.url && req.url.startsWith && req.url.substring && req.url.startsWith( getPathFromUrl(serverOptions.streamClientUrl) ) && getPathFromUrl(serverOptions.streamClientUrl) !== '/') {
             // make sure we strip off that path
             req.url = req.url.substring( getPathFromUrl(serverOptions.streamClientUrl).length );
             if(proxyOptions.logLevel === 'debug') {

--- a/src/app/admin/load/load.component.html
+++ b/src/app/admin/load/load.component.html
@@ -14,8 +14,12 @@
       Errors encountered during a stream load are indicated by the presence of this element.
     </span>
   </div>
-  useSocketStream: {{useSocketStream}}<br/>
-  canUseSocketStream: {{canUseSocketStream}}
+  <ul>
+    <li>useSocketStream: {{ useSocketStream }}</li>
+    <li>canUseSocketStream: {{ canUseSocketStream }}</li>
+    <li>adminBulkDataService.useStreamingForLoad: {{ adminBulkDataService.useStreamingForLoad }}</li>
+    <li>aboutInfoService.isPocServerInstance: {{ aboutInfoService.isPocServerInstance }}</li>
+  </ul>
   <div class="stream-connection-idicator" *ngIf="useSocketStream && canUseSocketStream">
     <mat-icon aria-hidden="false" aria-label="stream is disconnected. click to connect." class="disconnected" 
       matTooltip="Disconnected from stream host. Click to connect/reconnect." 

--- a/src/app/admin/load/load.component.html
+++ b/src/app/admin/load/load.component.html
@@ -14,13 +14,14 @@
       Errors encountered during a stream load are indicated by the presence of this element.
     </span>
   </div>
+  <!-- debug
   <ul>
     <li>useSocketStream: {{ useSocketStream }}</li>
     <li>canUseSocketStream: {{ canUseSocketStream }}</li>
     <li>adminBulkDataService.useStreamingForLoad: {{ adminBulkDataService.useStreamingForLoad }}</li>
     <li>aboutInfoService.isPocServerInstance: {{ aboutInfoService.isPocServerInstance }}</li>
-  </ul>
-  <div class="stream-connection-idicator" *ngIf="useSocketStream && canUseSocketStream">
+  </ul>-->
+  <!--<div class="stream-connection-idicator" *ngIf="useSocketStream && canUseSocketStream">
     <mat-icon aria-hidden="false" aria-label="stream is disconnected. click to connect." class="disconnected" 
       matTooltip="Disconnected from stream host. Click to connect/reconnect." 
       matTooltipClass="tooltip-red" 
@@ -30,7 +31,7 @@
       matTooltip="Connected to stream host. Click to disconnect."
       matTooltipPosition="left" 
       *ngIf="streamConnected" (click)="setStreamState(false)">flash_on</mat-icon>
-  </div>
+  </div>-->
   <div class="stream-loading" *ngIf="canSwitchFromStreamingToHttp">
     <mat-slide-toggle [(ngModel)]="useSocketStream">Stream Connection</mat-slide-toggle>
   </div>

--- a/src/app/admin/load/load.component.html
+++ b/src/app/admin/load/load.component.html
@@ -14,7 +14,9 @@
       Errors encountered during a stream load are indicated by the presence of this element.
     </span>
   </div>
-  <!--<div class="stream-connection-idicator" *ngIf="useSocketStream && canUseSocketStream">
+  useSocketStream: {{useSocketStream}}<br/>
+  canUseSocketStream: {{canUseSocketStream}}
+  <div class="stream-connection-idicator" *ngIf="useSocketStream && canUseSocketStream">
     <mat-icon aria-hidden="false" aria-label="stream is disconnected. click to connect." class="disconnected" 
       matTooltip="Disconnected from stream host. Click to connect/reconnect." 
       matTooltipClass="tooltip-red" 
@@ -24,7 +26,7 @@
       matTooltip="Connected to stream host. Click to disconnect."
       matTooltipPosition="left" 
       *ngIf="streamConnected" (click)="setStreamState(false)">flash_on</mat-icon>
-  </div>-->
+  </div>
   <div class="stream-loading" *ngIf="canSwitchFromStreamingToHttp">
     <mat-slide-toggle [(ngModel)]="useSocketStream">Stream Connection</mat-slide-toggle>
   </div>

--- a/src/app/admin/load/load.component.ts
+++ b/src/app/admin/load/load.component.ts
@@ -8,9 +8,10 @@ import { Subject } from 'rxjs';
 import { AdminStreamConnDialogComponent } from '../../common/stream-conn-dialog/stream-conn-dialog.component';
 import { AdminStreamLoadErrorsDialogComponent } from '../../common/stream-load-errors-dialog/stream-load-errors-dialog.component';
 import { AdminBulkDataService, AdminStreamAnalysisSummary, AdminStreamLoadSummary, AdminStreamSummaryError } from '../../services/admin.bulk-data.service';
-import { SzPrefsService, AdminStreamAnalysisConfig, AdminStreamConnProperties, AdminStreamLoadConfig } from '@senzing/sdk-components-ng';
+import { SzPrefsService } from '@senzing/sdk-components-ng';
 import { AboutInfoService } from '../../services/about.service';
 import { AdminBulkDataLoadComponent } from '../bulk-data/admin-bulk-data-load.component';
+import { AdminStreamAnalysisConfig, AdminStreamConnProperties, AdminStreamLoadConfig } from '../../common/models/AdminStreamConnection';
 
 @Component({
   selector: 'admin-data-loader',

--- a/src/app/common/models/AdminStreamConnection.ts
+++ b/src/app/common/models/AdminStreamConnection.ts
@@ -1,0 +1,21 @@
+
+// were overridding this one temporarily for prototyping purposes
+export interface AdminStreamConnProperties {
+    connected: boolean;
+    clientId?: string;
+    hostname: string;
+    port?: number;
+    secure?: boolean;
+    connectionTest: boolean;
+    reconnectOnClose: boolean;
+    reconnectConsecutiveAttemptLimit: number;
+    path: string;
+    method?: string;
+    /** url explicitly overrides any of the individual connection properties.
+    it is used for cloud environments where the client needs to open up 
+    socket connections to loadbalancers/gateways that don't correspond to 
+    anything on the local instance  */
+    url?: string;
+}
+// now export the rest of the bad bunnys
+export { AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '@senzing/sdk-components-ng';

--- a/src/app/common/stream-abort-dialog/stream-abort-dialog.component.ts
+++ b/src/app/common/stream-abort-dialog/stream-abort-dialog.component.ts
@@ -3,8 +3,7 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dial
 import { WebSocketService } from '../../services/websocket.service';
 import { AdminBulkDataService } from '../../services/admin.bulk-data.service';
 
-//import { AdminStreamConnProperties } from '../../services/admin.bulk-data.service';
-import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '@senzing/sdk-components-ng';
+import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '../../common/models/AdminStreamConnection';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 

--- a/src/app/common/stream-conn-dialog/stream-conn-dialog.component.ts
+++ b/src/app/common/stream-conn-dialog/stream-conn-dialog.component.ts
@@ -4,8 +4,7 @@ import { WebSocketService } from '../../services/websocket.service';
 import { AdminBulkDataService } from '../../services/admin.bulk-data.service';
 import { SzWebAppConfigService } from '../../services/config.service';
 
-//import { AdminStreamConnProperties } from '../../services/admin.bulk-data.service';
-import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '@senzing/sdk-components-ng';
+import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '../../common/models/AdminStreamConnection';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 import { getHostnameFromUrl, getPortFromUrl } from '../../common/url-utilities';

--- a/src/app/common/stream-load-errors-dialog/stream-load-error-collapseable.component.ts
+++ b/src/app/common/stream-load-errors-dialog/stream-load-error-collapseable.component.ts
@@ -1,7 +1,6 @@
 import { AfterViewInit, Component, EventEmitter, HostBinding, HostListener, Inject, Input, OnDestroy, OnInit, Output } from '@angular/core';
 import { AdminBulkDataService, AdminStreamSummaryError } from '../../services/admin.bulk-data.service';
 
-//import { AdminStreamConnProperties } from '../../services/admin.bulk-data.service';
 import { takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 

--- a/src/app/common/stream-load-errors-dialog/stream-load-errors-dialog.component.ts
+++ b/src/app/common/stream-load-errors-dialog/stream-load-errors-dialog.component.ts
@@ -3,8 +3,6 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dial
 import { WebSocketService } from '../../services/websocket.service';
 import { AdminBulkDataService, AdminStreamSummaryError } from '../../services/admin.bulk-data.service';
 
-//import { AdminStreamConnProperties } from '../../services/admin.bulk-data.service';
-import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '@senzing/sdk-components-ng';
 import { debounceTime, filter, takeUntil } from 'rxjs/operators';
 import { Subject } from 'rxjs';
 

--- a/src/app/common/stream-load-queue-dialog/stream-load-queue-dialog.component.ts
+++ b/src/app/common/stream-load-queue-dialog/stream-load-queue-dialog.component.ts
@@ -2,10 +2,7 @@ import { AfterViewInit, Component, Inject, OnDestroy, OnInit } from '@angular/co
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { WebSocketService } from '../../services/websocket.service';
 import { AdminBulkDataService } from '../../services/admin.bulk-data.service';
-
-//import { AdminStreamConnProperties } from '../../services/admin.bulk-data.service';
-import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates } from '@senzing/sdk-components-ng';
-import { takeUntil } from 'rxjs/operators';
+import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig } from '../../common/models/AdminStreamConnection';
 import { Subject } from 'rxjs';
 
 @Component({

--- a/src/app/common/stream-load-queue-dialog/stream-load-queue-info.component.ts
+++ b/src/app/common/stream-load-queue-dialog/stream-load-queue-info.component.ts
@@ -3,8 +3,7 @@ import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dial
 import { WebSocketService } from '../../services/websocket.service';
 import { AdminBulkDataService } from '../../services/admin.bulk-data.service';
 
-//import { AdminStreamConnProperties } from '../../services/admin.bulk-data.service';
-import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig, AdminStreamUploadRates, SzQueueInfoResponse, SzQueueInfo } from '@senzing/sdk-components-ng';
+import { SzQueueInfoResponse, SzQueueInfo } from '@senzing/sdk-components-ng';
 import { switchMap, takeUntil } from 'rxjs/operators';
 import { BehaviorSubject, Subject, timer } from 'rxjs';
 

--- a/src/app/common/url-utilities.ts
+++ b/src/app/common/url-utilities.ts
@@ -56,3 +56,23 @@ export function getProtocolFromUrl(url: string) {
         return protocol;
     }
 }
+
+export function getPathFromUrl(url: string) {
+    if(!url) return;
+    if( url ) {
+        let path    = '';
+        if(url.indexOf && url.indexOf('://') > -1) {
+            let urlTokened = url.split('://');
+            let strPath  = urlTokened[1];
+            if(strPath.indexOf && strPath.indexOf('/') > -1) {
+                path = strPath.substring(strPath.indexOf('/'));
+            } else {
+                // no "/" in url
+            }
+        } else if(url.indexOf && url.indexOf('/') > -1) {
+            // no protocol, assume first "/" to end
+            path = url.substring(url.indexOf('/'));
+        }
+        return path;
+    }
+}

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -1557,11 +1557,13 @@ export class AdminBulkDataService {
             this.useStreamingForLoad = isValid;
             this.useStreamingForAnalysis = isValid;
             this.useStreaming = isValid;
+            console.warn('successful stream test! ', this.useStreaming);
         }, (error: Error) => {
             connectionProperties.connectionTest = false;
             this.useStreamingForLoad = false;
             this.useStreamingForAnalysis = false;
             this.useStreaming = false;
+            console.warn('stream connection test failure! ', this.useStreaming);
         })
     }
 

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -1557,13 +1557,11 @@ export class AdminBulkDataService {
             this.useStreamingForLoad = isValid;
             this.useStreamingForAnalysis = isValid;
             this.useStreaming = isValid;
-            console.warn('successful stream test! ', this.useStreaming);
         }, (error: Error) => {
             connectionProperties.connectionTest = false;
             this.useStreamingForLoad = false;
             this.useStreamingForAnalysis = false;
             this.useStreaming = false;
-            console.warn('stream connection test failure! ', this.useStreaming);
         })
     }
 

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -365,7 +365,10 @@ export class AdminBulkDataService {
                 return result && result !== undefined;
             })
         ).subscribe((result: POCStreamConfig) => {
-            this.testStreamLoadingConnection(result);
+            //console.info('AdminBulkDataService.configService.onPocStreamConfigChange: ', result, this.aboutService.loadQueueConfigured, this.aboutService);
+            if(this.aboutService.isPocServerInstance && this.aboutService.isAdminEnabled && this.aboutService.loadQueueConfigured) {
+                this.testStreamLoadingConnection(result);
+            }
         });
 
         this.webSocketService.onError.subscribe((error: Error) => {

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -3,10 +3,10 @@ import { CanActivate, Router } from '@angular/router';
 import { ActivatedRouteSnapshot } from '@angular/router';
 import { Observable, of, from, interval, Subject, BehaviorSubject, timer } from 'rxjs';
 import { map, catchError, tap, switchMap, takeUntil, take, filter, takeWhile, delay } from 'rxjs/operators';
-import { SzConfigurationService, SzAdminService, SzEntityTypesService, SzServerInfo, SzPrefsService, SzBulkDataService, SzDataSourcesService } from '@senzing/sdk-components-ng';
-import { HttpClient } from '@angular/common/http';
+import { SzAdminService, SzEntityTypesService, SzPrefsService, SzBulkDataService, SzDataSourcesService } from '@senzing/sdk-components-ng';
 import { AuthConfig, POCStreamConfig, SzWebAppConfigService } from './config.service';
-import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig } from '@senzing/sdk-components-ng';
+import { getHostnameFromUrl, getPortFromUrl, getProtocolFromUrl, getPathFromUrl } from '../common/url-utilities';
+import { AdminStreamConnProperties, AdminStreamAnalysisConfig, AdminStreamLoadConfig } from '../common/models/AdminStreamConnection';
 
 import {
     determineLineEndingStyle,
@@ -1527,6 +1527,7 @@ export class AdminBulkDataService {
     }
 
     public testStreamLoadingConnection(pocConfig: POCStreamConfig) {        
+
         let connectionProperties: AdminStreamConnProperties = {
             "path": pocConfig.proxy.path ? pocConfig.proxy.path : '',
             "hostname": pocConfig.proxy ? pocConfig.proxy.hostname +(pocConfig.proxy.port ? ':'+ pocConfig.proxy.port : '') : pocConfig.target,
@@ -1534,6 +1535,9 @@ export class AdminBulkDataService {
             "connectionTest": false,
             "reconnectOnClose": false,
             "reconnectConsecutiveAttemptLimit": 10
+        }
+        if(pocConfig.proxy.url) {
+            connectionProperties.url        = pocConfig.proxy.url;
         }
 
         this.webSocketService.testConnection( connectionProperties ).subscribe((isValid: boolean) => {

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -81,8 +81,25 @@ export class SzWebAppConfigService {
       this._apiConfig = apiConf;
       if(this._apiConfig.basePath !== this.sdkConfigService.basePath) {
         this.sdkConfigService.basePath    = this._apiConfig.basePath;
+        this._onApiConfigChange.next( this._apiConfig );
         //console.warn('SzWebAppConfigService.getRuntimeApiConfig: set SDK basePath', apiConf);
       }
+    });
+    this.onApiConfigChange.pipe(
+      take(5)
+    ).subscribe(() => {
+      this.getRuntimeAuthConfig().pipe(
+        take(1)
+      ).subscribe((authConf: AuthConfig) => {
+        this._authConfig = authConf;
+      });
+      this.getRuntimeStreamConfig().pipe(
+        take(1)
+      ).subscribe((pocConf: POCStreamConfig) => {
+        this._pocStreamConfig = pocConf;
+        this._onPocStreamConfigChange.next( this._pocStreamConfig );
+        //console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
+      });
     });
     this.getRuntimeAuthConfig().pipe(
       take(1)

--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -88,8 +88,7 @@ export class WebSocketService {
         // override base path
         retVal = connProps.url;
         console.warn(`getSocketUriFromConnectionObject #1: ${retVal}`, connProps.url);
-      }
-      if(connProps.path) {
+      } else if(connProps.path) {
         retVal += connProps.path;
         console.warn(`getSocketUriFromConnectionObject #2: ${retVal}`, connProps.path);
       }

--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -3,7 +3,7 @@ import { BehaviorSubject, CompletionObserver, Observable, of, PartialObserver, S
 import { take, takeUntil, filter, map, tap, catchError, takeWhile } from 'rxjs/operators';
 import { webSocket, WebSocketSubject } from 'rxjs/webSocket';
 //import { v4 as uuidv4 } from 'uuid';
-import { AdminStreamConnProperties } from '@senzing/sdk-components-ng';
+import { AdminStreamConnProperties } from '../common/models/AdminStreamConnection';
 import { POCStreamConfig, SzWebAppConfigService } from './config.service';
 
 interface offlineMessage {
@@ -84,11 +84,25 @@ export class WebSocketService {
       retVal  = (connProps.secure) ? "wss://" : "ws://";
       retVal += (connProps.hostname) ? connProps.hostname : 'localhost';
       retVal += (connProps.port) ? ':'+connProps.port : '';
+      if(connProps.url) {
+        // override base path
+        retVal = connProps.url;
+      }
       if(connProps.path) {
         retVal += connProps.path;
       }
       if(path) {
         retVal += ''+ path;
+      }
+      // make sure we catch double "//" for sanity-sakes
+      if(retVal && retVal.lastIndexOf('//') > 4) {
+        if(retVal.indexOf('://') > -1) {
+          let tokened = retVal.split('://');
+          retVal  = tokened[0] +'://'+ tokened[1].split('//').join('/');
+        } else {
+          // no protocol
+          retVal  = retVal.split('//').join('/');
+        }
       }
     }
 
@@ -424,6 +438,7 @@ export class WebSocketService {
 
     if(connectionProps) {
       let _wsaddr = WebSocketService.getSocketUriFromConnectionObject(connectionProps, "/load-queue/bulk-data/records", "POST");
+      console.warn('testConnection: '+ _wsaddr, connectionProps);
 
       const openSubject = new Subject<Event>();
       openSubject.pipe(

--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -87,14 +87,11 @@ export class WebSocketService {
       if(connProps.url) {
         // override base path
         retVal = connProps.url;
-        console.warn(`getSocketUriFromConnectionObject #1: ${retVal}`, connProps.url);
       } else if(connProps.path) {
         retVal += connProps.path;
-        console.warn(`getSocketUriFromConnectionObject #2: ${retVal}`, connProps.path);
       }
       if(path) {
         retVal += ''+ path;
-        console.warn(`getSocketUriFromConnectionObject #3: ${retVal}`, path);
       }
       // make sure we catch double "//" for sanity-sakes
       if(retVal && retVal.lastIndexOf('//') > 4) {
@@ -107,8 +104,6 @@ export class WebSocketService {
         }
       }
     }
-    console.warn(`getSocketUriFromConnectionObject #4: ${retVal}`);
-
     return retVal;
   }
 

--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -87,12 +87,15 @@ export class WebSocketService {
       if(connProps.url) {
         // override base path
         retVal = connProps.url;
+        console.warn(`getSocketUriFromConnectionObject #1: ${retVal}`, connProps.url);
       }
       if(connProps.path) {
         retVal += connProps.path;
+        console.warn(`getSocketUriFromConnectionObject #2: ${retVal}`, connProps.path);
       }
       if(path) {
         retVal += ''+ path;
+        console.warn(`getSocketUriFromConnectionObject #3: ${retVal}`, path);
       }
       // make sure we catch double "//" for sanity-sakes
       if(retVal && retVal.lastIndexOf('//') > 4) {
@@ -105,6 +108,7 @@ export class WebSocketService {
         }
       }
     }
+    console.warn(`getSocketUriFromConnectionObject #4: ${retVal}`);
 
     return retVal;
   }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #192 

## Why was change needed

To support the web client opening up a websocket connection to an address that is different from the container host, ie: `wss://loadbalancer.gateway/app/ws` (external) ~> `ws://${internalFormationTunnel}:5255/app/ws` (internal)

## What does change improve

Ability to route websockets over secure gateway like cognito.
There are two new variables that are being added:
- `SENZING_WEB_SERVER_STREAM_CLIENT_URL` which is that *_public_* url that the user's browser tries to open up a connection to. This overrides the default which is to use `ws://SENZING_WEB_SERVER_URL` and if that isn't set it defaults to whatever is pulled from `ws://${hostname}:${port}${virtualDir}`. Sometimes it's necessary to open up a socket to an address that is external to the webapp that round-robbins.
- `SENZING_WEB_SERVER_INTERNAL_URL` which is the *_internal_* value of the web server's container. normally this defaults to `SENZING_WEB_SERVER_URL` but in certain configurations(**cough** *ecs* **cough**) you need to use a different *_INTERNAL_* container address than that.