### PR TITLE
Removal of "entity types" mapping and "datasource" UX remapping adjustments

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -18,6 +18,7 @@ import { SzWebAppConfigService } from '../services/config.service';
 import { AdminComponent } from './admin/admin.component';
 import { AdminDataSourcesComponent } from './datasources/datasources.component';
 import { AdminDataLoaderComponent } from './load/load.component';
+import { AdminEntityTypesComponent } from './entity-types/entity-types.component';
 import { AdminOAuthTokensComponent } from './tokens/tokens.component';
 import { AuthGuardService } from '../services/ag.service';
 import { AdminErrorNoAdminModeComponent } from './errors/no-admin.component';
@@ -42,6 +43,11 @@ const routes: Routes = [
               path: 'datasources',
               canActivate: [AuthGuardService],
               component: AdminDataSourcesComponent
+          },
+          {
+              path: 'entity-types',
+              canActivate: [AuthGuardService],
+              component: AdminEntityTypesComponent
           },
           {
               path: 'load',

--- a/src/app/admin/admin.module.ts
+++ b/src/app/admin/admin.module.ts
@@ -10,6 +10,7 @@ import { SenzingSdkGraphModule } from '@senzing/sdk-graph-components';
 import { AdminRoutingModule } from './admin-routing.module';
 import { AdminComponent } from './admin/admin.component';
 import { AdminDataSourcesComponent, NewDataSourceDialogComponent } from './datasources/datasources.component';
+import { AdminEntityTypesComponent } from './entity-types/entity-types.component';
 import { AdminDataLoaderComponent } from './load/load.component';
 import { AdminOAuthTokensComponent } from './tokens/tokens.component';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
@@ -44,6 +45,7 @@ import { SzWebAppConfigService } from '../services/config.service';
   declarations: [
     AdminComponent,
     AdminDataSourcesComponent,
+    AdminEntityTypesComponent,
     AdminDataLoaderComponent,
     AdminBulkDataAnalysisComponent,
     AdminBulkDataAnalysisReportComponent,

--- a/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.html
+++ b/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.html
@@ -1,28 +1,4 @@
 <!-- start BulkDataAnalysisReport -->
-<!-- <table *ngIf="analysis" class="data-source-mapping-plain">
-  <tr>
-    <th>Record Data Source</th>
-    <th>Number of Records</th>
-    <th>Records with Record ID</th>
-    <th>Map to Data Source</th>
-  </tr>
-  <tr *ngFor="let dsa of analysis.analysisByDataSource; let l = index;">
-    <td>{{ dsa.dataSource && dsa.dataSource.trim().length > 0 ? dsa.dataSource : '[NONE]' }}</td>
-    <td>{{ dsa.recordCount }}</td>
-    <td>{{ dsa.recordsWithRecordIdCount }}</td>
-    <td class="data-source-map">
-      <input type="text" placeholder="Choose a Data Source" #targetDS
-             [value]="dataSources.indexOf(dsa.dataSource) >= 0 ? dsa.dataSource : ''"
-             [attr.list]="'ds-name-'+l"
-             (change)="handleDataSourceChange(dsa.dataSource, targetDS.value)">
-      <datalist #dataSourceOptions [id]="'ds-name-'+l">
-        <option *ngFor="let dataSource of dataSources" [value]="dataSource" (click)="handleDataSourceChange(dsa.dataSource,  dataSource)">{{dataSource}}</option>
-      </datalist>
-      <span *ngIf="targetDS.value && (targetDS.value.trim().length > 0) && (dataSources.indexOf(targetDS.value) < 0)">new</span>
-    </td>
-  </tr>
-</table> -->
-<!-- start BulkDataAnalysisReport -->
 <table *ngIf="analysis && !currentError" mat-table [dataSource]="comboAnalysis" class="mat-table-full-width mat-elevation-z8">
 
   <!--- Note that these columns can be defined in any order.
@@ -77,81 +53,7 @@
       </div>
     </td>
   </ng-container>
-  <!-- Map to Entity Type Column -->
-  <!--<ng-container matColumnDef="entityType">
-    <th mat-header-cell *matHeaderCellDef > Map to Entity Type </th>
-    <td mat-cell *matCellDef="let element">
-      <mat-form-field class="example-full-width">
-        <input
-        matInput
-        type="text" placeholder="Entity Type to map to" #targetET
-        [value]="defaultIfUndefined(element.entityType,'GENERIC')"
-        [attr.list]="getEntityTypeInputName(l)"
-        matBadgeOverlap="true"
-        (change)="handleEntityTypeChange(element.entityType, targetET.value)">
-      </mat-form-field>
-      <datalist #entityTypeOptions [id]="getEntityTypeInputName(l)">
-        <option *ngFor="let eType of entityTypes" [value]="eType" (click)="handleEntityTypeChange(element.entityType,  eType)">{{eType}}</option>
-      </datalist>
-      <span class="mat-badge"
-      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
-      matBadgePosition="after"
-      matBadgeSize="medium"
-      [matBadgeHidden]="!isNewEntityType( targetET.value )"></span>
-    </td>
-  </ng-container>-->
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
-<!-- end BulkDataAnalysisReport (single ds, single etype) -->
-
-<!-- start entity type map table -->
-<!-- instead of commenting out just "falsey"'d the if statement until were sure 
-     were not going to use this -->
-<table *ngIf="false" mat-table [dataSource]="analysis.analysisByEntityType" class="mat-table-full-width mat-elevation-z8">
-
-  <!--- Note that these columns can be defined in any order.
-        The actual rendered columns are set as a property on the row definition" -->
-  <!-- Id Column -->
-  <ng-container matColumnDef="entityType">
-    <th mat-header-cell *matHeaderCellDef>Record Entity Type</th>
-    <td mat-cell *matCellDef="let element"> {{ element.entityType && element.entityType.trim().length > 0 ? element.entityType : '[NONE]' }}</td>
-  </ng-container>
-
-  <!-- number of records Column -->
-  <ng-container matColumnDef="recordCount">
-    <th mat-header-cell *matHeaderCellDef > Number of Records </th>
-    <td mat-cell *matCellDef="let element"> {{element.recordCount}} </td>
-  </ng-container>
-  <!-- Records with Record ID Column -->
-  <ng-container matColumnDef="recordsWithRecordIdCount">
-    <th mat-header-cell *matHeaderCellDef > Records with Record ID </th>
-    <td mat-cell *matCellDef="let element"> {{element.recordsWithRecordIdCount}} </td>
-  </ng-container>
-  <!-- Map to Entity Type Column -->
-  <ng-container matColumnDef="entityTypeCode">
-    <th mat-header-cell *matHeaderCellDef > Map to Entity Type </th>
-    <td mat-cell *matCellDef="let element">
-      <mat-form-field class="example-full-width">
-        <input
-        matInput
-        type="text" placeholder="Entity Type to map to" #targetET
-        [value]="defaultIfUndefined(element.entityType,'GENERIC')"
-        [attr.list]="getEntityTypeInputName(l)"
-        matBadgeOverlap="true"
-        (change)="handleEntityTypeChange(element.entityType, targetET.value)">
-      </mat-form-field>
-      <datalist #entityTypeOptions [id]="getEntityTypeInputName(l)">
-        <option *ngFor="let eType of entityTypes" [value]="eType" (click)="handleEntityTypeChange(element.entityType,  eType)">{{eType}}</option>
-      </datalist>
-      <span class="mat-badge"
-      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
-      matBadgePosition="after"
-      matBadgeSize="medium"
-      [matBadgeHidden]="!isNewEntityType( targetET.value )"></span>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="entityTypeColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: entityTypeColumns;"></tr>
-</table>
-<!-- end BulkDataAnalysisReport (single ds, single etype) -->
+<!-- end BulkDataAnalysisReport -->

--- a/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.html
+++ b/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.html
@@ -30,7 +30,13 @@
   <!-- Id Column -->
   <ng-container matColumnDef="dataSource">
     <th mat-header-cell *matHeaderCellDef>Record Data Source</th>
-    <td mat-cell *matCellDef="let element"> {{ element.dataSource && element.dataSource.trim().length > 0 ? element.dataSource : '[NONE]' }}</td>
+    <td mat-cell *matCellDef="let element">
+      {{ element.dataSource && element.dataSource.trim().length > 0 ? element.dataSource : '[NONE]' }}
+      <span *ngIf="isNewDataDource( element.dataSource )" class="mat-badge-ds-new-tag"
+      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
+      matBadgePosition="after"
+      matBadgeSize="medium"></span>
+    </td>
   </ng-container>
 
   <!-- number of records Column -->
@@ -47,27 +53,32 @@
   <ng-container matColumnDef="dataSourceCode">
     <th mat-header-cell *matHeaderCellDef > Map to Data Source </th>
     <td mat-cell *matCellDef="let element">
-      <mat-form-field class="example-full-width">
-        <input
-        matInput
-        type="text" placeholder="Data Source to map to" #targetDS
-        [value]="element.dataSource"
-        [attr.list]="getDataSourceInputName(l)"
-        matBadgeOverlap="true"
-        (change)="handleDataSourceChange(element.dataSource, targetDS.value)">
-      </mat-form-field>
-      <datalist #dataSourceOptions [id]="getDataSourceInputName(l)">
-        <option *ngFor="let dataSource of dataSources" [value]="dataSource" (click)="handleDataSourceChange(element.dataSource,  dataSource)">{{dataSource}}</option>
-      </datalist>
-      <span class="mat-badge"
-      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
-      matBadgePosition="after"
-      matBadgeSize="medium"
-      [matBadgeHidden]="!isNewDataDource( targetDS.value )"></span>
+      <!--<div *ngIf="element && element.dataSource">
+        {{element.dataSource}}
+      </div>-->
+      <div *ngIf="element && !element.dataSource">
+        <mat-form-field class="example-full-width">
+          <input
+          matInput
+          type="text" placeholder="Data Source to map to" #targetDS
+          [value]="element.dataSource"
+          [attr.list]="getDataSourceInputName(l)"
+          matBadgeOverlap="true"
+          (change)="handleDataSourceChange(element.dataSource, targetDS.value)">
+        </mat-form-field>
+        <datalist #dataSourceOptions [id]="getDataSourceInputName(l)">
+          <option *ngFor="let dataSource of dataSources" [value]="dataSource" (click)="handleDataSourceChange(element.dataSource,  dataSource)">{{dataSource}}</option>
+        </datalist>
+        <span class="mat-badge"
+        matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
+        matBadgePosition="after"
+        matBadgeSize="medium"
+        [matBadgeHidden]="!isNewDataDource( targetDS.value )"></span>
+      </div>
     </td>
   </ng-container>
   <!-- Map to Entity Type Column -->
-  <ng-container matColumnDef="entityType">
+  <!--<ng-container matColumnDef="entityType">
     <th mat-header-cell *matHeaderCellDef > Map to Entity Type </th>
     <td mat-cell *matCellDef="let element">
       <mat-form-field class="example-full-width">
@@ -88,14 +99,16 @@
       matBadgeSize="medium"
       [matBadgeHidden]="!isNewEntityType( targetET.value )"></span>
     </td>
-  </ng-container>
+  </ng-container>-->
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
 <!-- end BulkDataAnalysisReport (single ds, single etype) -->
 
 <!-- start entity type map table -->
-<table *ngIf="analysis && !currentError && isMoreThanOneEntityType" mat-table [dataSource]="analysis.analysisByEntityType" class="mat-table-full-width mat-elevation-z8">
+<!-- instead of commenting out just "falsey"'d the if statement until were sure 
+     were not going to use this -->
+<table *ngIf="false" mat-table [dataSource]="analysis.analysisByEntityType" class="mat-table-full-width mat-elevation-z8">
 
   <!--- Note that these columns can be defined in any order.
         The actual rendered columns are set as a property on the row definition" -->

--- a/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.html
+++ b/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.html
@@ -1,5 +1,5 @@
 <!-- start BulkDataAnalysisReport -->
-<table *ngIf="analysis && !currentError" mat-table [dataSource]="comboAnalysis" class="mat-table-full-width mat-elevation-z8">
+<table *ngIf="analysis && !currentError" mat-table [dataSource]="analysis.analysisByDataSource" class="mat-table-full-width mat-elevation-z8">
 
   <!--- Note that these columns can be defined in any order.
         The actual rendered columns are set as a property on the row definition" -->

--- a/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.scss
+++ b/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.scss
@@ -28,3 +28,14 @@
     }
   }
 }
+
+.mat-badge-ds-new-tag {
+  height: 13px;
+  width: 25px;
+
+  .mat-badge-content {
+    right: 0px;
+    left: 4px;
+    top: -4px;
+  }
+}

--- a/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.ts
+++ b/src/app/admin/bulk-data/admin-bulk-data-analysis-report.component.ts
@@ -11,10 +11,6 @@ import { takeUntil } from 'rxjs/operators';
 //import { MatTableDataSource } from '@angular/material/table';
 import { AdminBulkDataService, AdminStreamLoadSummary, AdminStreamAnalysisSummary } from '../../services/admin.bulk-data.service';
 
-export interface SzBulkDataComboAnalysis extends SzEntityTypeRecordAnalysis {
-  entityType?: string;
-}
-
 /**
  * Provides a visual report for a file analysis request.
  *
@@ -32,9 +28,10 @@ export class AdminBulkDataAnalysisReportComponent implements OnInit, OnDestroy, 
   /** subscription to notify subscribers to unbind */
   public unsubscribe$ = new Subject<void>();
   public get displayedColumns(): string[] {
-    const retVal = ['dataSource', 'recordCount', 'recordsWithRecordIdCount', 'dataSourceCode'];
-    if( !this.isMoreThanOneDataSource && !this.isMoreThanOneEntityType) {
-      retVal.push('entityType');
+    const retVal = [];
+    retVal.push('dataSource', 'recordCount', 'recordsWithRecordIdCount');
+    if( this.hasBlankDataSource) {
+      retVal.push('dataSourceCode');
     }
     return retVal;
   }
@@ -107,14 +104,13 @@ export class AdminBulkDataAnalysisReportComponent implements OnInit, OnDestroy, 
       return (this.analysis && this.analysis.analysisByEntityType && this.analysis.analysisByEntityType.length > 1);
     }
 
-    public get comboAnalysis() {
-      if(!this.isMoreThanOneDataSource && !this.isMoreThanOneEntityType) {
-        const retVal: SzBulkDataComboAnalysis[] = this.analysis.analysisByDataSource;
-        retVal[0].entityType = this.analysis.analysisByEntityType[0].entityType;
-        return retVal;
-      } else {
-        return this.analysis.analysisByDataSource;
-      }
+    /** check whether or not the analyzed file has any records with no datasource */
+    public get hasBlankDataSource() {
+      let retVal =  true;
+      retVal = this.analysis.analysisByDataSource ? this.analysis.analysisByDataSource.some((item) => {
+        return (item && item.dataSource === null || !item.dataSource);
+      }) : false;
+      return retVal;
     }
 
     ngOnInit() {

--- a/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.html
+++ b/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.html
@@ -23,7 +23,7 @@
   </tr>
 </table> -->
 <!-- start BulkDataAnalysisReport -->
-<table *ngIf="analysis && !currentError" mat-table [dataSource]="comboAnalysis" class="mat-table-full-width mat-elevation-z8">
+<table *ngIf="analysis && !currentError" mat-table [dataSource]="analysis.analysisByDataSource" class="mat-table-full-width mat-elevation-z8">
   <!--- Note that these columns can be defined in any order.
         The actual rendered columns are set as a property on the row definition" -->
   <!-- Id Column -->
@@ -73,81 +73,7 @@
       </div>
     </td>
   </ng-container>
-  <!-- Map to Entity Type Column -->
-  <!--<ng-container matColumnDef="entityType">
-    <th mat-header-cell *matHeaderCellDef > Map to Entity Type </th>
-    <td mat-cell *matCellDef="let element">
-      <mat-form-field class="example-full-width">
-        <input
-        matInput
-        type="text" placeholder="Entity Type to map to" #targetET
-        [value]="defaultIfUndefined(element.entityType,'GENERIC')"
-        [attr.list]="getEntityTypeInputName(l)"
-        matBadgeOverlap="true"
-        (change)="handleEntityTypeChange(element.entityType, targetET.value)">
-      </mat-form-field>
-      <datalist #entityTypeOptions [id]="getEntityTypeInputName(l)">
-        <option *ngFor="let eType of entityTypes" [value]="eType" (click)="handleEntityTypeChange(element.entityType,  eType)">{{eType}}</option>
-      </datalist>
-      <span class="mat-badge"
-      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
-      matBadgePosition="after"
-      matBadgeSize="medium"
-      [matBadgeHidden]="!isNewEntityType( targetET.value )"></span>
-    </td>
-  </ng-container>-->
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
-</table>
-<!-- end BulkDataAnalysisReport (single ds, single etype) -->
-
-<!-- start entity type map table -->
-<!-- instead of commenting out just "falsey"'d the if statement until were sure 
-     were not going to use this -->
-<table *ngIf="false" mat-table [dataSource]="analysis.analysisByEntityType" class="mat-table-full-width mat-elevation-z8">
-
-  <!--- Note that these columns can be defined in any order.
-        The actual rendered columns are set as a property on the row definition" -->
-  <!-- Id Column -->
-  <ng-container matColumnDef="entityType">
-    <th mat-header-cell *matHeaderCellDef>Record Entity Type</th>
-    <td mat-cell *matCellDef="let element"> {{ element.entityType && element.entityType.trim().length > 0 ? element.entityType : '[NONE]' }}</td>
-  </ng-container>
-
-  <!-- number of records Column -->
-  <ng-container matColumnDef="recordCount">
-    <th mat-header-cell *matHeaderCellDef > Number of Records </th>
-    <td mat-cell *matCellDef="let element"> {{element.recordCount}} </td>
-  </ng-container>
-  <!-- Records with Record ID Column -->
-  <ng-container matColumnDef="recordsWithRecordIdCount">
-    <th mat-header-cell *matHeaderCellDef > Records with Record ID </th>
-    <td mat-cell *matCellDef="let element"> {{element.recordsWithRecordIdCount}} </td>
-  </ng-container>
-  <!-- Map to Entity Type Column -->
-  <ng-container matColumnDef="entityTypeCode">
-    <th mat-header-cell *matHeaderCellDef > Map to Entity Type </th>
-    <td mat-cell *matCellDef="let element">
-      <mat-form-field class="example-full-width">
-        <input
-        matInput
-        type="text" placeholder="Entity Type to map to" #targetET
-        [value]="defaultIfUndefined(element.entityType,'GENERIC')"
-        [attr.list]="getEntityTypeInputName(l)"
-        matBadgeOverlap="true"
-        (change)="handleEntityTypeChange(element.entityType, targetET.value)">
-      </mat-form-field>
-      <datalist #entityTypeOptions [id]="getEntityTypeInputName(l)">
-        <option *ngFor="let eType of entityTypes" [value]="eType" (click)="handleEntityTypeChange(element.entityType,  eType)">{{eType}}</option>
-      </datalist>
-      <span class="mat-badge"
-      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
-      matBadgePosition="after"
-      matBadgeSize="medium"
-      [matBadgeHidden]="!isNewEntityType( targetET.value )"></span>
-    </td>
-  </ng-container>
-  <tr mat-header-row *matHeaderRowDef="entityTypeColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: entityTypeColumns;"></tr>
 </table>
 <!-- end BulkDataAnalysisReport (single ds, single etype) -->

--- a/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.html
+++ b/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.html
@@ -29,7 +29,13 @@
   <!-- Id Column -->
   <ng-container matColumnDef="dataSource">
     <th mat-header-cell *matHeaderCellDef>Record Data Source</th>
-    <td mat-cell *matCellDef="let element"> {{ element.dataSource && element.dataSource.trim().length > 0 ? element.dataSource : '[NONE]' }}</td>
+    <td mat-cell *matCellDef="let element">
+      {{ element.dataSource && element.dataSource.trim().length > 0 ? element.dataSource : '[NONE]' }}
+      <span *ngIf="isNewDataDource( element.dataSource )" class="mat-badge-ds-new-tag"
+        matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
+        matBadgePosition="after"
+        matBadgeSize="medium"></span>
+    </td>
   </ng-container>
 
   <!-- number of records Column -->
@@ -46,27 +52,29 @@
   <ng-container matColumnDef="dataSourceCode">
     <th mat-header-cell *matHeaderCellDef > Map to Data Source </th>
     <td mat-cell *matCellDef="let element">
-      <mat-form-field class="example-full-width">
-        <input
-        matInput
-        type="text" placeholder="Data Source to map to" #targetDS
-        [value]="element.dataSource"
-        [attr.list]="getDataSourceInputName(l)"
-        matBadgeOverlap="true"
-        (change)="handleDataSourceChange(element.dataSource, targetDS.value)">
-      </mat-form-field>
-      <datalist #dataSourceOptions [id]="getDataSourceInputName(l)">
-        <option *ngFor="let dataSource of dataSources" [value]="dataSource" (click)="handleDataSourceChange(element.dataSource,  dataSource)">{{dataSource}}</option>
-      </datalist>
-      <span class="mat-badge"
-      matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
-      matBadgePosition="after"
-      matBadgeSize="medium"
-      [matBadgeHidden]="!isNewDataDource( targetDS.value )"></span>
+      <div *ngIf="element && !element.dataSource">
+        <mat-form-field class="example-full-width">
+          <input
+          matInput
+          type="text" placeholder="Data Source to map to" #targetDS
+          [value]="element.dataSource"
+          [attr.list]="getDataSourceInputName(l)"
+          matBadgeOverlap="true"
+          (change)="handleDataSourceChange(element.dataSource, targetDS.value)">
+        </mat-form-field>
+        <datalist #dataSourceOptions [id]="getDataSourceInputName(l)">
+          <option *ngFor="let dataSource of dataSources" [value]="dataSource" (click)="handleDataSourceChange(element.dataSource,  dataSource)">{{dataSource}}</option>
+        </datalist>
+        <span class="mat-badge"
+        matBadge="new" matBadgeOverlap="false" matBadgeDescription="New Data Source"
+        matBadgePosition="after"
+        matBadgeSize="medium"
+        [matBadgeHidden]="!isNewDataDource( targetDS.value )"></span>
+      </div>
     </td>
   </ng-container>
   <!-- Map to Entity Type Column -->
-  <ng-container matColumnDef="entityType">
+  <!--<ng-container matColumnDef="entityType">
     <th mat-header-cell *matHeaderCellDef > Map to Entity Type </th>
     <td mat-cell *matCellDef="let element">
       <mat-form-field class="example-full-width">
@@ -87,14 +95,16 @@
       matBadgeSize="medium"
       [matBadgeHidden]="!isNewEntityType( targetET.value )"></span>
     </td>
-  </ng-container>
+  </ng-container>-->
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
   <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
 </table>
 <!-- end BulkDataAnalysisReport (single ds, single etype) -->
 
 <!-- start entity type map table -->
-<table *ngIf="analysis && !currentError && isMoreThanOneEntityType" mat-table [dataSource]="analysis.analysisByEntityType" class="mat-table-full-width mat-elevation-z8">
+<!-- instead of commenting out just "falsey"'d the if statement until were sure 
+     were not going to use this -->
+<table *ngIf="false" mat-table [dataSource]="analysis.analysisByEntityType" class="mat-table-full-width mat-elevation-z8">
 
   <!--- Note that these columns can be defined in any order.
         The actual rendered columns are set as a property on the row definition" -->

--- a/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.scss
+++ b/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.scss
@@ -28,3 +28,14 @@
     }
   }
 }
+
+.mat-badge-ds-new-tag {
+  height: 13px;
+  width: 25px;
+
+  .mat-badge-content {
+    right: 0px;
+    left: 4px;
+    top: -4px;
+  }
+}

--- a/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.ts
+++ b/src/app/admin/bulk-data/admin-bulk-data-stream-analysis-report.component.ts
@@ -11,10 +11,6 @@ import { takeUntil } from 'rxjs/operators';
 //import { MatTableDataSource } from '@angular/material/table';
 import { AdminBulkDataService, AdminStreamLoadSummary, AdminStreamAnalysisSummary } from '../../services/admin.bulk-data.service';
 
-export interface SzBulkDataComboAnalysis extends SzEntityTypeRecordAnalysis {
-  entityType?: string;
-}
-
 /**
  * Provides a visual report for a file analysis request.
  *
@@ -32,9 +28,10 @@ export class AdminBulkDataStreamAnalysisReportComponent implements OnInit, OnDes
   /** subscription to notify subscribers to unbind */
   public unsubscribe$ = new Subject<void>();
   public get displayedColumns(): string[] {
-    const retVal = ['dataSource', 'recordCount', 'recordsWithRecordIdCount', 'dataSourceCode'];
-    if( !this.isMoreThanOneDataSource && !this.isMoreThanOneEntityType) {
-      retVal.push('entityType');
+    const retVal = [];
+    retVal.push('dataSource', 'recordCount', 'recordsWithRecordIdCount');
+    if( this.hasBlankDataSource) {
+      retVal.push('dataSourceCode');
     }
     return retVal;
   }
@@ -101,23 +98,13 @@ export class AdminBulkDataStreamAnalysisReportComponent implements OnInit, OnDes
     public get isMoreThanOneDataSource() {
       return (this.analysis && this.analysis.dataSources && this.analysis.dataSources.length > 1) ? true : false;
     }
-    public get isMoreThanOneEntityType() {
-      let retVal = false;
-      if(this.analysis && this.analysis.analysisByEntityType && this.analysis.analysisByEntityType.length) {
-        retVal = (this.analysis.analysisByEntityType.length > 1) ? true : false;
-      } else if (this.analysis && this.analysis.entityTypes && this.analysis.entityTypes.length > 1) {
-        retVal = true;
-      }
+    /** check whether or not the analyzed file has any records with no datasource */
+    public get hasBlankDataSource() {
+      let retVal = (this.analysis && this.analysis.dataSources) ? true : false;
+      retVal = this.analysis.analysisByDataSource ? this.analysis.analysisByDataSource.some((item) => {
+        return (item && item.dataSource === null || !item.dataSource);
+      }) : false;
       return retVal;
-    }
-    public get comboAnalysis() {
-      if(!this.isMoreThanOneDataSource && !this.isMoreThanOneEntityType) {
-        const retVal: SzBulkDataComboAnalysis[] = this.analysis.analysisByDataSource;
-        retVal[0].entityType = this.analysis.analysisByEntityType[0].entityType;
-        return retVal;
-      } else {
-        return this.analysis.analysisByDataSource;
-      }
     }
 
     ngOnInit() {

--- a/src/app/admin/datasources/datasources.component.html
+++ b/src/app/admin/datasources/datasources.component.html
@@ -32,7 +32,8 @@
   </table>
 </div>
 <div class="form-group form-actions">
-  <button mat-stroked-button color="primary" class="btn btn-primary" type="button" (click)="openNewDataSourceDialog()">New Data Source</button>
+  <button mat-stroked-button color="primary" class="btn btn-primary" type="button" (click)="openNewDataSourceDialog()"><mat-icon>add</mat-icon>New Data Source</button>
+  <button mat-stroked-button color="primary" class="btn btn-primary" type="button" (click)="updateDataSourcesList()"><mat-icon>refresh</mat-icon>Refresh</button>
 </div>
 <!-- start spinner overlay -->
 <div class="mat-background" *ngIf="loading">

--- a/src/app/admin/datasources/datasources.component.scss
+++ b/src/app/admin/datasources/datasources.component.scss
@@ -3,5 +3,15 @@
 :host {
   .form-actions {
     margin: 30px 0 0 0;
+
+    display: inline-flex;
+    flex-direction: row;
+
+    button {
+      margin-right: 10px;
+      &:last-child {
+        margin-right: none;
+      }
+    }
   }
 }

--- a/src/app/admin/datasources/datasources.component.ts
+++ b/src/app/admin/datasources/datasources.component.ts
@@ -58,7 +58,7 @@ export class AdminDataSourcesComponent implements OnInit {
     this.adminBulkDataService.onDataSourcesChange.subscribe(this.updateDataSourcesList.bind(this));
   }
 
-  private updateDataSourcesList() {
+  public updateDataSourcesList() {
     this._loading = true;
     this.datasourcesServices.listDataSourcesDetails().subscribe( (data: SzDataSourcesResponseData) => {
       this.dataSourcesData = data.dataSourceDetails;

--- a/src/app/admin/datasources/datasources.component.ts
+++ b/src/app/admin/datasources/datasources.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, Inject } from '@angular/core';
+import { Component, OnInit, ViewChild, Inject, AfterViewInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { SzDataSourcesService, SzDataSourcesResponseData, SzDataSourcesResponse, SzDataSource } from '@senzing/sdk-components-ng';
 import { Observable } from 'rxjs';
@@ -6,6 +6,7 @@ import { map } from 'rxjs/operators';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { AdminBulkDataService } from '../../services/admin.bulk-data.service';
 
 export interface DialogData {
   name: string;
@@ -43,6 +44,7 @@ export class AdminDataSourcesComponent implements OnInit {
   }
 
   constructor(
+    private adminBulkDataService: AdminBulkDataService,
     private datasourcesServices: SzDataSourcesService,
     private titleService: Title,
     public dialog: MatDialog
@@ -52,7 +54,8 @@ export class AdminDataSourcesComponent implements OnInit {
     this.datasource.paginator = this.paginator;
     // set page title
     this.titleService.setTitle( 'Admin Area - Data Sources' );
-    this.updateDataSourcesList();
+    this._loading = true;
+    this.adminBulkDataService.onDataSourcesChange.subscribe(this.updateDataSourcesList.bind(this));
   }
 
   private updateDataSourcesList() {

--- a/src/app/admin/entity-types/entity-types.component.html
+++ b/src/app/admin/entity-types/entity-types.component.html
@@ -37,9 +37,9 @@
     <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
   </table>
 </div>
-<!--<div class="form-group form-actions">
-  <button mat-stroked-button color="primary" class="btn btn-primary" type="button" (click)="openNewDataSourceDialog()">New Data Source</button>
-</div>-->
+<div class="form-group form-actions">
+  <button mat-stroked-button color="primary" class="btn btn-primary" type="button" (click)="updateEntityTypesList()"><mat-icon>refresh</mat-icon>Refresh</button>
+</div>
 <!-- start spinner overlay -->
 <div class="mat-background" *ngIf="loading">
   <div class="spinner">

--- a/src/app/admin/entity-types/entity-types.component.html
+++ b/src/app/admin/entity-types/entity-types.component.html
@@ -1,0 +1,53 @@
+<h2 class="section-title">
+  Entity Types
+  <mat-paginator [pageSizeOptions]="[10, 20, 50]" [pageSize]="10" showFirstLastButtons></mat-paginator>
+</h2>
+<!-- <div class="section-instructions">
+  <p>Please, Don-Bot… look into your hard drive, and open your mercy file! All I want is to be a monkey of moderate intelligence who wears a suit… that's why I'm transferring to business school!</p>
+  <p>A sexy mistake. Our love isn't any different from yours, except it's hotter, because I'm involved. I am Singing Wind, Chief of the Martians. That's not soon enough!</p>
+  <p>Soon enough. Yes, I saw. You were doing well, until everyone died. But I've never been to the moon! I'm sorry, guys. I never meant to hurt you. Just to destroy everything you ever believed in. Hey! I'm a porno-dealing monster, what do I care what you think?</p>
+  <p>Oh, I don't have time for this. I have to go and buy a single piece of fruit with a coupon and then return it, making people wait behind me while I complain. Bite my shiny metal ass. Look, everyone wants to be like Germany, but do we really have the pure strength of 'will'?</p>
+  <p>You won't have time for sleeping, soldier, not with all the bed making you'll be doing. Leela, Bender, we're going grave robbing. Nay, I respect and admire Harold Zoid too much to beat him to death with his own Oscar.</p>
+  <p>Look, last night was a mistake. Check it out, y'all. Everyone who was invited is here. No argument here. OK, if everyone's finished being stupid. For example, if you killed your grandfather, you'd cease to exist!</p>
+</div> -->
+<div>
+  <table mat-table matSort [dataSource]="datasource" class="mat-elevation-z8">
+    <!--- Note that these columns can be defined in any order.
+          The actual rendered columns are set as a property on the row definition" -->
+
+    <!-- Id Column -->
+    <ng-container matColumnDef="entityTypeId">
+      <th mat-header-cell *matHeaderCellDef class="header-cell"> Entity Type Id</th>
+      <td mat-cell *matCellDef="let element"> {{element.entityTypeId}} </td>
+    </ng-container>
+
+    <!-- Name Column -->
+    <ng-container matColumnDef="entityTypeCode">
+      <th mat-header-cell *matHeaderCellDef> Name </th>
+      <td mat-cell *matCellDef="let element"> {{element.entityTypeCode}} </td>
+    </ng-container>
+
+    <!-- Class Column -->
+    <ng-container matColumnDef="entityClassCode">
+      <th mat-header-cell *matHeaderCellDef> Class </th>
+      <td mat-cell *matCellDef="let element"> {{element.entityClassCode}} </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+  </table>
+</div>
+<!--<div class="form-group form-actions">
+  <button mat-stroked-button color="primary" class="btn btn-primary" type="button" (click)="openNewDataSourceDialog()">New Data Source</button>
+</div>-->
+<!-- start spinner overlay -->
+<div class="mat-background" *ngIf="loading">
+  <div class="spinner">
+      <div class="rect1"></div>
+      <div class="rect2"></div>
+      <div class="rect3"></div>
+      <div class="rect4"></div>
+      <div class="rect5"></div>
+  </div>
+</div>
+<!-- end spinner overlay -->

--- a/src/app/admin/entity-types/entity-types.component.scss
+++ b/src/app/admin/entity-types/entity-types.component.scss
@@ -1,0 +1,7 @@
+@import '../../scss/_admin.scss';
+
+:host {
+  .form-actions {
+    margin: 30px 0 0 0;
+  }
+}

--- a/src/app/admin/entity-types/entity-types.component.ts
+++ b/src/app/admin/entity-types/entity-types.component.ts
@@ -1,0 +1,116 @@
+import { Component, OnInit, ViewChild, Inject } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { 
+  SzEntityTypesService, SzEntityType,
+} from '@senzing/sdk-components-ng';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { MatTableDataSource } from '@angular/material/table';
+import { MatPaginator } from '@angular/material/paginator';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+
+export interface DialogData {
+  name: string;
+}
+
+@Component({
+  selector: 'admin-entity-types',
+  templateUrl: './entity-types.component.html',
+  styleUrls: ['./entity-types.component.scss']
+})
+export class AdminEntityTypesComponent implements OnInit {
+  displayedColumns: string[] = ['entityTypeId', 'entityTypeCode'];
+  public datasource:  MatTableDataSource<SzEntityType> = new MatTableDataSource<SzEntityType>();
+
+  @ViewChild(MatPaginator) paginator: MatPaginator;
+
+  private _entityTypesData: {
+    [id: string]: SzEntityType;
+  };
+  private set entityTypesData(value: {
+    [id: string]: SzEntityType;
+  }) {
+    this._entityTypesData = value;
+    console.log('entityTypesData = ', value);
+
+    if(this._entityTypesData) {
+      this.datasource.data = Object.values( this._entityTypesData );
+    }
+  }
+
+  private _loading: boolean = false;
+  private _dialogOpen: boolean = false;
+
+  public get loading(): boolean {
+    return this._loading;
+  }
+
+  constructor(
+    private entityTypesServices: SzEntityTypesService,
+    private titleService: Title,
+    public dialog: MatDialog
+  ) { }
+
+  ngOnInit() {
+    this.datasource.paginator = this.paginator;
+    // set page title
+    this.titleService.setTitle( 'Admin Area - Entity Types' );
+    this.updateEntityTypesList();
+  }
+
+  private updateEntityTypesList() {
+    this._loading = true;
+    this.entityTypesServices.listEntityTypesDetails().subscribe( 
+      (data: {[key: string]: SzEntityType;}) => {
+        console.log('listEntityTypesDetails: ', data);
+        this.entityTypesData = data;
+        this._loading = false;
+      }, (err) => {
+        console.error('hey', err);
+      } );
+  }
+
+  /*
+  public openNewDataSourceDialog() {
+    if(!this._dialogOpen) {
+      const dialogRef = this.dialog.open(NewDataSourceDialogComponent, {
+        width: '400px',
+        data: { name: '' }
+      });
+
+      dialogRef.afterClosed().subscribe(dsName => {
+        if(dsName && dsName.length > 0) {
+          this.datasourcesServices.addDataSources([ dsName ]).subscribe(
+            (result) => {
+              console.log('created new datasource', result);
+              this.updateDataSourcesList();
+            }
+          );
+        }
+        this._dialogOpen = false;
+      });
+    }
+  }*/
+
+}
+/*
+@Component({
+  selector: 'admin-add-datasource-dialog',
+  templateUrl: 'add-datasource.component.html',
+  styleUrls: ['./add-datasource.component.scss']
+})
+export class NewDataSourceDialogComponent {
+
+  constructor(
+    public dialogRef: MatDialogRef<NewDataSourceDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: DialogData) {}
+
+  onNoClick(): void {
+    this.dialogRef.close();
+  }
+
+  public isEmpty(value: any): boolean {
+    return (value && value.trim() === '');
+  }
+
+}*/

--- a/src/app/admin/entity-types/entity-types.component.ts
+++ b/src/app/admin/entity-types/entity-types.component.ts
@@ -19,7 +19,7 @@ export interface DialogData {
   styleUrls: ['./entity-types.component.scss']
 })
 export class AdminEntityTypesComponent implements OnInit {
-  displayedColumns: string[] = ['entityTypeId', 'entityTypeCode'];
+  displayedColumns: string[] = ['entityTypeId', 'entityTypeCode', 'entityClassCode'];
   public datasource:  MatTableDataSource<SzEntityType> = new MatTableDataSource<SzEntityType>();
 
   @ViewChild(MatPaginator) paginator: MatPaginator;
@@ -31,7 +31,6 @@ export class AdminEntityTypesComponent implements OnInit {
     [id: string]: SzEntityType;
   }) {
     this._entityTypesData = value;
-    console.log('entityTypesData = ', value);
 
     if(this._entityTypesData) {
       this.datasource.data = Object.values( this._entityTypesData );

--- a/src/app/admin/entity-types/entity-types.component.ts
+++ b/src/app/admin/entity-types/entity-types.component.ts
@@ -8,6 +8,7 @@ import { map } from 'rxjs/operators';
 import { MatTableDataSource } from '@angular/material/table';
 import { MatPaginator } from '@angular/material/paginator';
 import { MatDialog, MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { AdminBulkDataService } from '../../services/admin.bulk-data.service';
 
 export interface DialogData {
   name: string;
@@ -45,6 +46,7 @@ export class AdminEntityTypesComponent implements OnInit {
   }
 
   constructor(
+    private adminBulkDataService: AdminBulkDataService,
     private entityTypesServices: SzEntityTypesService,
     private titleService: Title,
     public dialog: MatDialog
@@ -54,10 +56,11 @@ export class AdminEntityTypesComponent implements OnInit {
     this.datasource.paginator = this.paginator;
     // set page title
     this.titleService.setTitle( 'Admin Area - Entity Types' );
-    this.updateEntityTypesList();
+    this._loading = true;
+    this.adminBulkDataService.onEntityTypesChange.subscribe(this.updateEntityTypesList.bind(this));
   }
 
-  private updateEntityTypesList() {
+  public updateEntityTypesList() {
     this._loading = true;
     this.entityTypesServices.listEntityTypesDetails().subscribe( 
       (data: {[key: string]: SzEntityType;}) => {
@@ -68,48 +71,4 @@ export class AdminEntityTypesComponent implements OnInit {
         console.error('hey', err);
       } );
   }
-
-  /*
-  public openNewDataSourceDialog() {
-    if(!this._dialogOpen) {
-      const dialogRef = this.dialog.open(NewDataSourceDialogComponent, {
-        width: '400px',
-        data: { name: '' }
-      });
-
-      dialogRef.afterClosed().subscribe(dsName => {
-        if(dsName && dsName.length > 0) {
-          this.datasourcesServices.addDataSources([ dsName ]).subscribe(
-            (result) => {
-              console.log('created new datasource', result);
-              this.updateDataSourcesList();
-            }
-          );
-        }
-        this._dialogOpen = false;
-      });
-    }
-  }*/
-
 }
-/*
-@Component({
-  selector: 'admin-add-datasource-dialog',
-  templateUrl: 'add-datasource.component.html',
-  styleUrls: ['./add-datasource.component.scss']
-})
-export class NewDataSourceDialogComponent {
-
-  constructor(
-    public dialogRef: MatDialogRef<NewDataSourceDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: DialogData) {}
-
-  onNoClick(): void {
-    this.dialogRef.close();
-  }
-
-  public isEmpty(value: any): boolean {
-    return (value && value.trim() === '');
-  }
-
-}*/

--- a/src/app/services/about.service.ts
+++ b/src/app/services/about.service.ts
@@ -4,7 +4,7 @@ import {
   RouterStateSnapshot,
   ActivatedRouteSnapshot,
 } from '@angular/router';
-import { Observable, interval, from, of, EMPTY, Subject } from 'rxjs';
+import { Observable, interval, from, of, EMPTY, Subject, BehaviorSubject } from 'rxjs';
 import { AdminService, SzBaseResponse, SzMeta, SzVersionResponse, SzVersionInfo } from '@senzing/rest-api-client-ng';
 import { switchMap, tap, takeWhile, map } from 'rxjs/operators';
 import { version as appVersion, dependencies as appDependencies } from '../../../package.json';
@@ -50,6 +50,11 @@ export class AboutInfoService {
   public isAdminEnabled: boolean;
   public isPocServerInstance: boolean = false;
   private pollingInterval = 60 * 1000;
+
+  /** provide a event subject to notify listeners of updates */
+  private _onServerInfoUpdated = new BehaviorSubject(this);
+  public onServerInfoUpdated = this._onServerInfoUpdated.asObservable();
+
   /** poll for version info */
   public pollForVersionInfo(): Observable<SzVersionInfo> {
     return interval(this.pollingInterval).pipe(
@@ -142,12 +147,14 @@ export class AboutInfoService {
     this.infoQueueConfigured      = info && info.infoQueueConfigured !== undefined ? info.infoQueueConfigured : this.infoQueueConfigured;
     this.loadQueueConfigured      = info && info.loadQueueConfigured !== undefined ? info.loadQueueConfigured : this.loadQueueConfigured;
     this.webSocketsMessageMaxSize = info && info.webSocketsMessageMaxSize !== undefined ? info.webSocketsMessageMaxSize : this.webSocketsMessageMaxSize;
+    this._onServerInfoUpdated.next(this);
   }
 
   private setPocServerInfo(resp: SzMeta) {
     this.pocServerVersion     = resp && resp.pocServerVersion ? resp.pocServerVersion : this.pocApiVersion;
     this.pocApiVersion        = resp && resp.pocApiVersion ? resp.pocApiVersion : this.pocApiVersion;
     this.isPocServerInstance  = resp && resp.pocApiVersion !== undefined ? true : this.isPocServerInstance;
+    this._onServerInfoUpdated.next(this);
   }
 
   private setVersionInfo(serverInfo: SzVersionInfo): void {

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -478,9 +478,10 @@ export class AdminBulkDataService {
         this.datasourcesService.listDataSources().pipe(
         takeUntil( this.unsubscribe$ )
         ).subscribe((datasources: string[]) => {
-        //console.log('datasources obtained: ', datasources);
-        this._dataSources = datasources.filter(s => s !== 'TEST' && s !== 'SEARCH');
-        this.onDataSourcesChange.next(this._dataSources);
+            //console.log('datasources obtained: ', datasources);
+            //this._dataSources = datasources.filter(s => s !== 'TEST' && s !== 'SEARCH');
+            this._dataSources = datasources;
+            this.onDataSourcesChange.next(this._dataSources);
         },
         (err) => {
         // ignore errors since this is a auto-req
@@ -494,7 +495,8 @@ export class AdminBulkDataService {
         takeUntil( this.unsubscribe$ )
         ).subscribe((entityTypes: string[]) => {
         //console.log('entity types obtained: ', entityTypes);
-        this._entityTypes = entityTypes.filter(s => s !== 'TEST' && s !== 'SEARCH');
+        //this._entityTypes = entityTypes.filter(s => s !== 'TEST' && s !== 'SEARCH');
+        this._entityTypes = entityTypes;
         this.onEntityTypesChange.next(this._entityTypes);
         },
         (err) => {

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -461,6 +461,12 @@ export class AdminBulkDataService {
         ).subscribe((info) => {
             //console.log('ServerInfo obtained: ', info);
         });
+        this.onDataSourceMapChange.subscribe((result) => {
+            console.warn('onDataSourceMapChange: ', result);
+        });
+        this.onEntityTypeMapChange.subscribe((result) => {
+            console.warn('onEntityTypeMapChange: ', result);
+        });
         this.updateDataSources();
         this.updateEntityTypes();
     }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, Inject } from '@angular/core';
 import { BehaviorSubject, Observable, of, Subject } from 'rxjs';
-import { catchError, take } from 'rxjs/operators';
+import { catchError, filter, take } from 'rxjs/operators';
 import { SzRestConfigurationParameters, SzConfigurationService } from '@senzing/sdk-components-ng';
 import { HttpClient } from '@angular/common/http';
+import { AboutInfoService } from './about.service';
 
 export interface AuthConfig {
   hostname?: string;
@@ -71,6 +72,7 @@ export class SzWebAppConfigService {
   public onPocStreamConfigChange                                      = this._onPocStreamConfigChange.asObservable();
 
   constructor( 
+    private aboutInfoService: AboutInfoService,
     private http: HttpClient,
     private sdkConfigService: SzConfigurationService
   ) {
@@ -89,13 +91,35 @@ export class SzWebAppConfigService {
     ).subscribe((authConf: AuthConfig) => {
       this._authConfig = authConf;
     });
-    this.getRuntimeStreamConfig().pipe(
-      take(1)
-    ).subscribe((pocConf: POCStreamConfig) => {
-      this._pocStreamConfig = pocConf;
-      this._onPocStreamConfigChange.next( this._pocStreamConfig );
-      //console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
-    });
+    if(this.aboutInfoService.isPocServerInstance && this.aboutInfoService.isAdminEnabled) {
+      this.getRuntimeStreamConfig().pipe(
+        filter(() => {
+          return this.aboutInfoService.isPocServerInstance && this.aboutInfoService.isAdminEnabled;
+        }),
+        take(1)
+      ).subscribe((pocConf: POCStreamConfig) => {
+        this._pocStreamConfig = pocConf;
+        this._onPocStreamConfigChange.next( this._pocStreamConfig );
+        console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
+      });
+    } else {
+      this.aboutInfoService.onServerInfoUpdated.pipe(
+        filter(() => {
+          return this.aboutInfoService.isPocServerInstance && this.aboutInfoService.isAdminEnabled;
+        })
+      ).subscribe((result) => {
+        this.getRuntimeStreamConfig().pipe(
+          filter(() => {
+            return this.aboutInfoService.isPocServerInstance && this.aboutInfoService.isAdminEnabled;
+          }),
+          take(1)
+        ).subscribe((pocConf: POCStreamConfig) => {
+          this._pocStreamConfig = pocConf;
+          this._onPocStreamConfigChange.next( this._pocStreamConfig );
+          console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
+        });
+      });
+    }
   }
   public getRuntimeAuthConfig(): Observable<AuthConfig> {
     // reach out to webserver to get auth


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #190 

## Why was change needed

- Per demo feedback the option to "re-map/map" **_entity-types_** found during import analysis flow has been removed.
- Per demo feedback if file contains a _**entity type**_ attached to a record and the _**entity type**_ does **_NOT_** already exist it is auto-created.
- Per demo feedback if file contains a **_datasource_** attached to a record and the **_datasource_** does not already exist it is auto-created on load phase.
- Per demo feedback if file has records that do not contain datasources attached to the record then the user will be prompted to enter a new one or select from the pre-existing options. 
- A new "entity types" route has been created solely for debug and is not exposed through UI.

## What does change improve

UX

![2021-09-02_154150](https://user-images.githubusercontent.com/13721038/131927091-bf8a00a6-6598-405b-bd0c-4405ebdb5392.png)
![2021-09-02_154317](https://user-images.githubusercontent.com/13721038/131927094-dee4f0e4-2ad1-4fd7-a032-c2faa12842ae.png)
![2021-09-02_155315](https://user-images.githubusercontent.com/13721038/131927148-21234fa3-def4-4112-8830-88bba4f9ef88.png)
