### PR TITLE
Issue196.awinters.1

### DIFF
--- a/src/app/services/websocket.service.ts
+++ b/src/app/services/websocket.service.ts
@@ -141,10 +141,22 @@ export class WebSocketService {
     let retSub = new Subject<boolean>();
     let retObs = retSub.asObservable();
     if((this.connectionProperties && !this._connected) || this.ws$ === undefined) {
-      //console.log('queueing message..', this._offlineMessageQueue.length, this._connected, this.ws$.closed);
+      //console.log('queueing messages..', this._offlineMessageQueue.length, this._connected, this.ws$.closed);
       this._offlineMessageQueue = this._offlineMessageQueue.concat(
-        (messages as any).map((message: any) => {
-          return {data: JSON.stringify(message)}
+        (messages as any).map((message: any | string) => {
+          let msgStr = '';
+          if((message as string).split) {
+            // string
+            msgStr = message;
+          } else {
+            // assume json object
+            msgStr = JSON.stringify(message);
+          }
+          if(msgStr && !(msgStr.lastIndexOf('\n') >= (msgStr.length > 2 ? msgStr.length - 2 : msgStr.length))) {
+            // add line ending
+            msgStr  = msgStr +'\n';
+          }
+          return {data: msgStr}
         })
       );
     } else if(this.ws$) {


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #196 

## Why was change needed

Stream-loading in aws exposed a missing bit of code in the offline message processing method. This missing code was responsible for enforcing that the messages sent to the websocket **_always_** ended with a **linebreak** char. Without that linebreak char the `poc-server` didn't know where one record starts/ends when the format is `json-l`

## What does change improve

stream loading will not function properly without that linebreak char being added.
