### PR TITLE
Disable admin no auth issue.awinters.1

### DIFF
--- a/src/app/admin/errors/no-admin.component.scss
+++ b/src/app/admin/errors/no-admin.component.scss
@@ -1,0 +1,5 @@
+:host {
+    h2 {
+        margin-top: 0px;
+    }
+}

--- a/src/app/services/admin.service.ts
+++ b/src/app/services/admin.service.ts
@@ -64,6 +64,11 @@ export class AdminAuthService {
    */
   public onAdminModeChange: Subject<boolean> =  new Subject<boolean>();
   /**
+   * when the state of the rest server "readOnly" flag is changed.
+   */
+  public onAdminReadOnlyChange: Subject<boolean> =  new Subject<boolean>();
+
+  /**
    * when the authenticated status of the current user has changed
    */
   public onAdminAuthenticatedChange: Subject<boolean> =  new Subject<boolean>();
@@ -211,5 +216,21 @@ export class AdminAuthService {
         if( _isChanged ) { this.onAdminModeChange.next( this.adminService.adminEnabled ); }
       })
     );
+  }
+  /** reach out to rest server to check whether or not the "adminEnabled" flag is set to true */
+  public checkIsReadOnly(): Observable<boolean> {
+    return this.adminService.getServerInfo().pipe(
+      map( (resp: SzServerInfo) => resp.readOnly ),
+      tap( (resp: boolean) => {
+        const _isChanged = (this.adminService.readOnly !== resp);
+        this.adminService.readOnly = resp;
+        //console.info('AdminAuthService.checkServerInfo: ', this.isAdminModeEnabled, _isChanged);
+        if( _isChanged ) { this.onAdminReadOnlyChange.next( this.adminService.readOnly ); }
+      })
+    );
+  }
+  /** reach out to rest server to check whether or not the "adminEnabled" flag is set to true */
+  public getServerInfo(): Observable<SzServerInfo> {
+    return this.adminService.getServerInfo();
   }
 }

--- a/src/app/services/ag.service.ts
+++ b/src/app/services/ag.service.ts
@@ -95,7 +95,7 @@ export class AuthGuardService implements CanActivate {
         if (!(authConf.admin && authConf.admin.mode)) {
           // no auth check. WWWWHHHHYYYY!!!
           // hope you know what you're doing
-          // console.warn('NO AUTH CHECK!!! EXTREMELY DANGEROUS!');
+          console.warn('NO AUTH CHECK!!! EXTREMELY DANGEROUS!');
           responseMap.noAuth = true;
           //responseMap.adminEnabled = true;
           retReq = of(true);
@@ -156,7 +156,7 @@ export class AuthGuardService implements CanActivate {
         if (!(responseMap.config.admin && responseMap.config.admin.mode)) {
           // no auth check. WWWWHHHHYYYY!!!
           // hope you know what you're doing
-          // console.warn('2 NO AUTH CHECK!!! EXTREMELY DANGEROUS!');
+          console.warn('2 NO AUTH CHECK!!! EXTREMELY DANGEROUS!');
           responseMap.noAuth = true;
           return of(true);
         } else {
@@ -175,6 +175,7 @@ export class AuthGuardService implements CanActivate {
           console.warn('redirecting to login: ', responseMap);
           this.redirectOnFailure();
         } else {
+          console.warn('ag true: ', responseMap);
           return of(true);
         }
       }),

--- a/src/app/services/ag.service.ts
+++ b/src/app/services/ag.service.ts
@@ -97,7 +97,7 @@ export class AuthGuardService implements CanActivate {
         if (!(authConf.admin && authConf.admin.mode)) {
           // no auth check. WWWWHHHHYYYY!!!
           // hope you know what you're doing
-          console.warn('NO AUTH CHECK!!! EXTREMELY DANGEROUS!');
+          //console.warn('NO AUTH CHECK!!! EXTREMELY DANGEROUS!');
           responseMap.noAuth = true;
           //responseMap.adminEnabled = true;
           retReq = of(true);
@@ -159,7 +159,7 @@ export class AuthGuardService implements CanActivate {
           // no auth check. WWWWHHHHYYYY!!!
           // hope you know what you're doing
           responseMap.noAuth = true;
-          console.warn('2 NO AUTH CHECK!!! EXTREMELY DANGEROUS!', responseMap);
+          //console.warn('2 NO AUTH CHECK!!! EXTREMELY DANGEROUS!', responseMap);
           return this.adminAuth.getServerInfo().pipe(
             tap((resi: SzServerInfo) => {
               responseMap.adminEnabled = resi.adminEnabled;
@@ -170,14 +170,11 @@ export class AuthGuardService implements CanActivate {
               return of(true)
             })
           );
-          //responseMap.noAuth = true;
-          //return of(true);
         } else {
           return this.adminAuth.getServerInfo().pipe(
             tap((resi: SzServerInfo) => {
               responseMap.adminEnabled = resi.adminEnabled;
               responseMap.readonly = resi.readOnly;
-              //responses.push(resi);
             }),
             map( (resi: SzServerInfo) => {
               return true
@@ -194,7 +191,6 @@ export class AuthGuardService implements CanActivate {
         } else if(!responseMap.adminEnabled){
           this.router.navigate( ['admin', 'error', 'admin-mode-disabled'] );
         } else {
-          console.warn('ag true: ', responseMap);
           return of(true);
         }
       }),


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #202 

## Why was change needed

To fix a `/admin` route authentication issue when `enableAdmin` not set and user explicitly sets admin authentication to `NONE`

## What does change improve

Redirects the user to the proper error page when `enableAdmin` not set to true regardless of whether or not admin authentication is set to `NONE`
