### PR TITLE
#204 debug

### DIFF
--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -991,9 +991,11 @@ export class AdminBulkDataService {
             //if(data && data.status === 'COMPLETED' && summary.sentRecordCount === summary.recordCount) {
                 // all data sent
                 summary.complete = true;
+            } else {
+                summary.complete = false;
             }
             if(readStreamComplete && sendStreamComplete && summary.complete === true) {
-                //console.warn('sending _onStreamLoadComplete: ', summary);
+                console.warn('sending _onStreamLoadComplete: ', summary, data);
                 this._onStreamLoadComplete.next(summary);
             } else {
                 //console.log('stream not complete', readStreamComplete, sendStreamComplete, summary.complete);
@@ -1083,7 +1085,7 @@ export class AdminBulkDataService {
                     //console.warn('stream load complete 1', summary);
                     sendStreamComplete = true;
                     if(summary.complete === true) {
-                        //console.warn('sending _onStreamLoadComplete 2: ', summary);
+                        console.warn('sending _onStreamLoadComplete 2: ', summary);
                         this._onStreamLoadComplete.next(summary);
                     }
                 } else {

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -880,8 +880,7 @@ export class AdminBulkDataService {
                 //this.onAnalysisChange.next( this.currentAnalysisResult );
             })
         ).subscribe((summary: AdminStreamAnalysisSummary) => {
-            console.log('onStreamAnalysisComplete: ', summary);
-
+            //console.log('onStreamAnalysisComplete: ', summary);
             if(readStreamComplete && summary) {
                 // set this to true to end batching loop Observeable
                 //console.warn('stream load complete 2', summary);

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -825,7 +825,7 @@ export class AdminBulkDataService {
 
         // read file contents as stream
         // parse to array of records
-        this.parseRecordsFromFile(file, (status) => {
+        let _onStreamRecordParserListener = this.parseRecordsFromFile(file, (status) => {
             // on stream complete, do thing
             //console.log('SzBulkDataService.streamAnalyze: file stream read complete.', status);
             readStreamComplete = true;
@@ -849,7 +849,7 @@ export class AdminBulkDataService {
         );
         
         // when ANYTHING changes, update the singleton "currentAnalysisResult" var so components can read status
-        retObs.subscribe((summary: AdminStreamAnalysisSummary) => {
+        let _onAdminStreamAnalysisSummaryChangedListener = retObs.subscribe((summary: AdminStreamAnalysisSummary) => {
             this.currentAnalysisResult = summary;
         });
 
@@ -867,7 +867,7 @@ export class AdminBulkDataService {
         });
 
         // on end of records queue double-check if whole thing is complete
-        this.onStreamAnalysisComplete.pipe(
+        let _onStreamAnalysisCompleteListener = this.onStreamAnalysisComplete.pipe(
             takeUntil(this.streamAnalysisAbort$),
             filter((summary: AdminStreamAnalysisSummary) => { return summary !== undefined;}),
             take(1),
@@ -888,6 +888,15 @@ export class AdminBulkDataService {
                 summary.complete = true;
             } else {
                 //console.warn('stream analysis complete 2', readStreamComplete, summary);
+            }
+            if(_onStreamAnalysisCompleteListener && _onStreamAnalysisCompleteListener.unsubscribe) {
+                _onStreamAnalysisCompleteListener.unsubscribe();
+            }
+            if(_onStreamRecordParserListener && _onStreamRecordParserListener.unsubscribe) {
+                _onStreamRecordParserListener.unsubscribe();
+            }
+            if(_onAdminStreamAnalysisSummaryChangedListener && _onAdminStreamAnalysisSummaryChangedListener.unsubscribe) {
+                _onAdminStreamAnalysisSummaryChangedListener.unsubscribe();
             }
         });
         return retObs;

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -976,7 +976,7 @@ export class AdminBulkDataService {
         //} else {
         //    console.log('SzBulkDataService.streamLoad: websocket thinks its still connected: ', this.webSocketService.connected, this.streamConnectionProperties);
         //}
-        this.webSocketService.onMessageRecieved.pipe(
+        let _onWSMessageRecievedListener = this.webSocketService.onMessageRecieved.pipe(
             filter( data => { return data !== undefined}),
             map( data => { return (data as AdminStreamLoadSummary) })
         ).subscribe((data: AdminStreamLoadSummary) => {
@@ -995,7 +995,7 @@ export class AdminBulkDataService {
                 summary.complete = false;
             }
             if(readStreamComplete && sendStreamComplete && summary.complete === true) {
-                console.warn('sending _onStreamLoadComplete: ', summary, data);
+                //console.warn('sending _onStreamLoadComplete: ', summary, data);
                 this._onStreamLoadComplete.next(summary);
             } else {
                 //console.log('stream not complete', readStreamComplete, sendStreamComplete, summary.complete);
@@ -1085,7 +1085,7 @@ export class AdminBulkDataService {
                     //console.warn('stream load complete 1', summary);
                     sendStreamComplete = true;
                     if(summary.complete === true) {
-                        console.warn('sending _onStreamLoadComplete 2: ', summary);
+                        //console.warn('sending _onStreamLoadComplete 2: ', summary);
                         this._onStreamLoadComplete.next(summary);
                     }
                 } else {
@@ -1172,7 +1172,7 @@ export class AdminBulkDataService {
         });*/
 
         // on end of records queue double-check if whole thing is complete
-        this._onStreamLoadComplete.pipe(
+        let _onStreamLoadCompleteListener = this._onStreamLoadComplete.pipe(
             takeUntil(this.streamLoadAbort$),
             filter((summary: AdminStreamLoadSummary) => { return summary !== undefined;}),
             take(5),
@@ -1182,6 +1182,12 @@ export class AdminBulkDataService {
             //setTimeout(() => {
                 console.log('closing connection: all data sent', summary);
                 this.webSocketService.disconnect();
+                if(_onWSMessageRecievedListener && _onWSMessageRecievedListener.unsubscribe) {
+                    _onWSMessageRecievedListener.unsubscribe();
+                }
+                if(_onStreamLoadCompleteListener && _onStreamLoadCompleteListener.unsubscribe) {
+                    _onStreamLoadCompleteListener.unsubscribe();
+                }
             //}, 3000)
         });
 

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -880,6 +880,8 @@ export class AdminBulkDataService {
                 //this.onAnalysisChange.next( this.currentAnalysisResult );
             })
         ).subscribe((summary: AdminStreamAnalysisSummary) => {
+            console.log('onStreamAnalysisComplete: ', summary);
+
             if(readStreamComplete && summary) {
                 // set this to true to end batching loop Observeable
                 //console.warn('stream load complete 2', summary);
@@ -1041,7 +1043,7 @@ export class AdminBulkDataService {
 
         // read file contents as stream
         // parse to array of records
-        this.parseRecordsFromFile(file, (status) => {
+        let _onStreamRecordParserListener = this.parseRecordsFromFile(file, (status) => {
             // on stream complete, do thing
             //console.warn('SzBulkDataService.streamLoad: file stream read complete.', status);
             readStreamComplete = true;
@@ -1128,7 +1130,7 @@ export class AdminBulkDataService {
         //}
         
         // when ANYTHING changes, update the singleton "currentLoadResult" var so components can read status
-        retObs.subscribe((summary: AdminStreamLoadSummary) => {
+        let _onAdminStreamLoadSummaryChangedListener = retObs.subscribe((summary: AdminStreamLoadSummary) => {
             this.currentLoadResult = summary;
         });
 
@@ -1188,6 +1190,12 @@ export class AdminBulkDataService {
                 if(_onStreamLoadCompleteListener && _onStreamLoadCompleteListener.unsubscribe) {
                     _onStreamLoadCompleteListener.unsubscribe();
                 }
+                if(_onStreamRecordParserListener && _onStreamRecordParserListener.unsubscribe) {
+                    _onStreamRecordParserListener.unsubscribe();
+                }
+                if(_onAdminStreamLoadSummaryChangedListener && _onAdminStreamLoadSummaryChangedListener.unsubscribe) {
+                    _onAdminStreamLoadSummaryChangedListener.unsubscribe();
+                }                
             //}, 3000)
         });
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #204 

## Why was change needed

When a user successfully loads a file through SQS, and then attempts to load another file without a page refresh the state of `.complete` is not fully cleared out of the load summary object resulting in a premature disconnection.

## What does change improve

user can load more than one file
