### PR TITLE
webapp keto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,62 +1,48 @@
-ARG BASE_IMAGE=node:lts-buster-slim
-FROM ${BASE_IMAGE}
+ARG BUILD_IMAGE=node:lts-buster-slim
+ARG PROD_IMAGE=node:lts-alpine
+ARG TEST_IMAGE=node:lts-buster-slim
 
+FROM ${BUILD_IMAGE}
 ENV REFRESHED_AT=2021-07-26
 
 LABEL Name="senzing/entity-search-web-app" \
       Maintainer="support@senzing.com" \
-      Version="2.2.4"
+      Version="2.3.3"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 
-# Run as "root" for system installation.
-
-USER root
-
-# Install WGET
-RUN apt-get -qq update \
- && apt-get install -qq -yq \
- wget \
- gnupg2
-
-# Install chrome for protractor tests.
-
-RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
- && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
- && apt-get -qq update \
- && apt-get -qq install -yq \
-    google-chrome-stable \
- && rm -rf /var/lib/apt/lists/*
-
 # Set working directory.
-
 WORKDIR /app
 
 # Add `/app/node_modules/.bin` to $PATH
-
 ENV PATH /app/node_modules/.bin:$PATH
 
 # Install and cache app dependencies.
-
 COPY package.json /app/package.json
 COPY package-lock.json /app/package-lock.json
 RUN npm config set loglevel warn \
  && npm install --silent \
  && npm install --silent -g @angular/cli@10.0.0
 
-# Copy files from repository.
+# Build app. build as root and switch back
 COPY ./rootfs /
 COPY . /app
-COPY --chown=1001:1001 ./proxy.conf.json /app
-
-# Build app. build as root and switch back
-USER root
 RUN npm run build:docker
 
-# Remove src tree after build
-RUN rm -fR /app/src
+# production output stage
+FROM ${PROD_IMAGE}
 
-USER 1001
+# Copy files from repository.
+COPY ./rootfs /
+COPY ./run /app/run
+COPY --from=0 /app/dist /app/dist
+RUN npm config set loglevel warn \
+ && npm install --silent --production
+
+#COPY . /app
+COPY --chown=1001:1001 ./proxy.conf.json /app
+
+#USER 1001
 
 # Runtime execution.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/entity-search-web-app",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "scripts": {
     "ng": "ng",
     "start": "npm run start:with:auth",

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -1,4 +1,4 @@
-const { calcProjectFileAndBasePath } = require("@angular/compiler-cli");
+//const { calcProjectFileAndBasePath } = require("@angular/compiler-cli");
 const { env } = require("process");
 const { getHostnameFromUrl, getPortFromUrl, getProtocolFromUrl, getRootFromUrl, replaceProtocol, getPathFromUrl } = require("./utils");
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #209 

## Why was change needed

slim down the production package
![2021-09-13_193141](https://user-images.githubusercontent.com/13721038/133185377-296fc3b0-61f8-45bd-bb21-5127dfc495a1.png)


## What does change improve

- production image switched to `node:lts-alpine`
- container image size goes from 1.62GB -> 620MB
- dependency vulnerabilities greatly reduced. (`node_modules` excluding dev dependencies)
- apt-get of google-chrome removed. It is needed for e2e testing, but it adds substantial attack surface. removing it for now, we'll split off e2e testing in a different way (one that doesn't require baking chrome in to the production container)
