### PR TITLE
misconfiguration of '/conf' paths by default

### DIFF
--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -510,6 +510,8 @@ function getProxyServerOptionsFromInput() {
   let retOpts = {
     authServerHostName: "localhost",
     authServerPortNumber: 8080,
+    confServerHostName: "localhost",
+    confServerPortNumber: 8080,
     logLevel: "error",
     apiServerUrl: "",
     configPath: "",
@@ -528,10 +530,13 @@ function getProxyServerOptionsFromInput() {
     }
     if(env.SENZING_AUTH_SERVER_HOSTNAME || env.SENZING_WEB_SERVER_HOSTNAME) {
       retOpts.authServerHostName    = (env.SENZING_AUTH_SERVER_HOSTNAME) ? env.SENZING_AUTH_SERVER_HOSTNAME : env.SENZING_WEB_SERVER_HOSTNAME;
+      retOpts.confServerHostName    = retOpts.authServerHostName;
     }
     if(env.SENZING_AUTH_SERVER_PORT || env.SENZING_WEB_SERVER_PORT) {
       retOpts.authServerPortNumber  = (env.SENZING_AUTH_SERVER_PORT) ? env.SENZING_AUTH_SERVER_PORT : env.SENZING_WEB_SERVER_PORT;
+      retOpts.confServerPortNumber  = retOpts.authServerPortNumber;
       retOpts.adminAuthPath         = "http://"+ retOpts.authServerHostName +":"+ retOpts.authServerPortNumber;
+      retOpts.configPath            = "http://"+ retOpts.confServerHostName +":"+ retOpts.confServerPortNumber;
     }
     if(env.SENZING_WEB_SERVER_AUTH_PATH) {
       retOpts.adminAuthPath = env.SENZING_WEB_SERVER_AUTH_PATH;
@@ -574,7 +579,10 @@ function getProxyServerOptionsFromInput() {
   if(cmdLineOpts && cmdLineOpts !== undefined) {
     if(cmdLineOpts.authServerPortNumber) {
       retOpts.authServerPortNumber  = cmdLineOpts.authServerPortNumber;
-      retOpts.adminAuthPath         = "http://localhost:"+ retOpts.authServerPortNumber;
+      retOpts.confServerPortNumber  = retOpts.authServerPortNumber;
+
+      retOpts.adminAuthPath         = "http://"+ retOpts.authServerHostName +":"+ retOpts.authServerPortNumber;
+      retOpts.configPath            = "http://"+ retOpts.confServerHostName +":"+ retOpts.confServerPortNumber;
     }
     if(cmdLineOpts.proxyLogLevel) {
       retOpts.logLevel = cmdLineOpts.proxyLogLevel;

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -326,6 +326,8 @@ class inMemoryConfig extends EventEmitter {
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
           console.log('--------------------------  onApiServerReady: stream loading disabled #2 --------------------------');
+          console.log(serverInfo.data);
+
           this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
       } else if(serverInfo.data && !serverInfo.data.adminEnabled) {

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -318,22 +318,26 @@ class inMemoryConfig extends EventEmitter {
           // poc server supports adding datasources and importing data
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
+          console.log('--------------------------  onApiServerReady: stream loading disabled #1 --------------------------');
           this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
         if(!serverInfo.data.loadQueueConfigured) {
           // poc server does not support loading through stream socket
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
+          console.log('--------------------------  onApiServerReady: stream loading disabled #2 --------------------------');
           this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
       } else if(serverInfo.data && !serverInfo.data.adminEnabled) {
         // standard rest server that supports loading data
         this.streamServerConfiguration = undefined;
         this.webConfiguration.streamLoading = false;
+        console.log('--------------------------  onApiServerReady: stream loading disabled #3 --------------------------');
         this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
       }
     } else {
       this.webConfiguration.streamLoading = false;
+      console.log('--------------------------  onApiServerReady: stream loading disabled #4 --------------------------');
       this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
     }
     // now notify any listeners that we fully have the data we need

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -318,28 +318,22 @@ class inMemoryConfig extends EventEmitter {
           // poc server supports adding datasources and importing data
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
-          console.log('--------------------------  onApiServerReady: stream loading disabled #1 --------------------------');
           this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
         if(!serverInfo.data.loadQueueConfigured) {
           // poc server does not support loading through stream socket
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
-          console.log('--------------------------  onApiServerReady: stream loading disabled #2 --------------------------');
-          console.log(serverInfo.data);
-
           this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
       } else if(serverInfo.data && !serverInfo.data.adminEnabled) {
         // standard rest server that supports loading data
         this.streamServerConfiguration = undefined;
         this.webConfiguration.streamLoading = false;
-        console.log('--------------------------  onApiServerReady: stream loading disabled #3 --------------------------');
         this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
       }
     } else {
       this.webConfiguration.streamLoading = false;
-      console.log('--------------------------  onApiServerReady: stream loading disabled #4 --------------------------');
       this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
     }
     // now notify any listeners that we fully have the data we need

--- a/run/runtime.datastore.js
+++ b/run/runtime.datastore.js
@@ -318,19 +318,23 @@ class inMemoryConfig extends EventEmitter {
           // poc server supports adding datasources and importing data
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
+          this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
         if(!serverInfo.data.loadQueueConfigured) {
           // poc server does not support loading through stream socket
           this.streamServerConfiguration = undefined;
           this.webConfiguration.streamLoading = false;
+          this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
         }
       } else if(serverInfo.data && !serverInfo.data.adminEnabled) {
         // standard rest server that supports loading data
         this.streamServerConfiguration = undefined;
         this.webConfiguration.streamLoading = false;
+        this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
       }
     } else {
       this.webConfiguration.streamLoading = false;
+      this.emit('streamLoadingChanged',this.webConfiguration.streamLoading);
     }
     // now notify any listeners that we fully have the data we need
     this._apiServerIsReady = true;

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -208,13 +208,14 @@ const authRes = (req, res, next) => {
   app.get(_confBasePath+'/conf/package', (req, res, next) => {
     res.status(200).json( packageInfo );
   });
-  if(streamOptions) {
-    app.get(_confBasePath+'/conf/streams', (req, res, next) => {
-        console.log('streams config: '+(_confBasePath+'/conf/streams'));
-        console.log('\n', streamOptions);
+
+  app.get(_confBasePath+'/conf/streams', (req, res, next) => {
+      if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
-    });
-  }
+      } else {
+        res.status(503);
+      }
+  });
 
   // ----------------- wildcards -----------------
   // we need a wildcarded version due to 
@@ -232,14 +233,13 @@ const authRes = (req, res, next) => {
   app.get('*/conf/package', (req, res, next) => {
     res.status(200).json( packageInfo );
   });
-  if(streamOptions) {
-    app.get('*/conf/streams', (req, res, next) => {
-      console.log('streams config: '+(_confBasePath+'/conf/streams'));
-      console.log('\n', streamOptions);
-
-      res.status(200).json( streamOptions );
-    });
-  }
+  app.get('*/conf/streams', (req, res, next) => {
+      if(streamOptions && streamOptions !== undefined) {
+        res.status(200).json( streamOptions );
+      } else {
+        res.status(503);
+      }
+  });
 
 // ----------------- end config endpoints -----------------
 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -213,6 +213,7 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
+        console.log('stream config: ',streamOptions);
         res.status(503).json();
       }
   });
@@ -237,6 +238,7 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
+        console.log('stream config: ',streamOptions);
         res.status(503).json();
       }
   });

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -210,6 +210,8 @@ const authRes = (req, res, next) => {
   });
 
   app.get(_confBasePath+'/conf/streams', (req, res, next) => {
+      console.log('streams config: '+(_confBasePath+'/conf/streams'));
+      console.log('\n', streamOptions);
       res.status(200).json( streamOptions );
   });
 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -213,6 +213,7 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
+        console.log('streaming not configured');
         res.status(503).json();
       }
   });
@@ -237,6 +238,7 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
+        console.log('streaming not configured');
         res.status(503).json();
       }
   });

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -213,7 +213,7 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
-        res.status(503);
+        res.status(503).json();
       }
   });
 
@@ -237,7 +237,7 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
-        res.status(503);
+        res.status(503).json();
       }
   });
 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -213,7 +213,6 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
-        console.log('streaming not configured');
         res.status(503).json();
       }
   });
@@ -238,7 +237,6 @@ const authRes = (req, res, next) => {
       if(streamOptions && streamOptions !== undefined) {
         res.status(200).json( streamOptions );
       } else {
-        console.log('streaming not configured');
         res.status(503).json();
       }
   });

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -25,6 +25,10 @@ console.log(inMemoryConfigFromInputs);
 console.log('--------------------------------------------------------');
 const runtimeOptions = new inMemoryConfig(inMemoryConfigFromInputs);
 
+runtimeOptions.on('streamLoadingChanged', (state) => {
+  console.log('--------------- STREAM LOADING: '+ state +' ---------------');
+})
+
 // auth options
 const authOptions = runtimeOptions.config.auth;
 const auth        = new AuthModule( runtimeOptions.config );

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -208,12 +208,13 @@ const authRes = (req, res, next) => {
   app.get(_confBasePath+'/conf/package', (req, res, next) => {
     res.status(200).json( packageInfo );
   });
-
-  app.get(_confBasePath+'/conf/streams', (req, res, next) => {
-      console.log('streams config: '+(_confBasePath+'/conf/streams'));
-      console.log('\n', streamOptions);
-      res.status(200).json( streamOptions );
-  });
+  if(streamOptions) {
+    app.get(_confBasePath+'/conf/streams', (req, res, next) => {
+        console.log('streams config: '+(_confBasePath+'/conf/streams'));
+        console.log('\n', streamOptions);
+        res.status(200).json( streamOptions );
+    });
+  }
 
   // ----------------- wildcards -----------------
   // we need a wildcarded version due to 
@@ -231,9 +232,14 @@ const authRes = (req, res, next) => {
   app.get('*/conf/package', (req, res, next) => {
     res.status(200).json( packageInfo );
   });
-  app.get('*/conf/streams', (req, res, next) => {
+  if(streamOptions) {
+    app.get('*/conf/streams', (req, res, next) => {
+      console.log('streams config: '+(_confBasePath+'/conf/streams'));
+      console.log('\n', streamOptions);
+
       res.status(200).json( streamOptions );
-  });
+    });
+  }
 
 // ----------------- end config endpoints -----------------
 

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -20,9 +20,6 @@ const { getPathFromUrl } = require("../utils");
 const AuthModule = require('../authserver/auth');
 const inMemoryConfig = require("../runtime.datastore");
 const inMemoryConfigFromInputs = require('../runtime.datastore.config');
-console.log('-------------------- RUNTIME CONFIG --------------------');
-console.log(inMemoryConfigFromInputs);
-console.log('--------------------------------------------------------');
 const runtimeOptions = new inMemoryConfig(inMemoryConfigFromInputs);
 
 runtimeOptions.on('streamLoadingChanged', (state) => {
@@ -450,7 +447,6 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
           resolve();
         });
       } else {
-        console.log('[disabled] WS Proxy Server');
         resolve();
       }
     }

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -20,6 +20,9 @@ const { getPathFromUrl } = require("../utils");
 const AuthModule = require('../authserver/auth');
 const inMemoryConfig = require("../runtime.datastore");
 const inMemoryConfigFromInputs = require('../runtime.datastore.config');
+console.log('-------------------- RUNTIME CONFIG --------------------');
+console.log(inMemoryConfigFromInputs);
+console.log('--------------------------------------------------------');
 const runtimeOptions = new inMemoryConfig(inMemoryConfigFromInputs);
 
 // auth options
@@ -443,6 +446,7 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
           resolve();
         });
       } else {
+        console.log('[disabled] WS Proxy Server');
         resolve();
       }
     }

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -25,7 +25,7 @@
   <hr>
   <div class="key">Admin Mode:</div>
   <div class="value" *ngIf="!aboutService.isAdminEnabled">Disabled</div>
-  <div class="value " style="flex-basis: unset; width: 100%;" *ngIf="aboutService.isAdminEnabled">
+  <div class="value " style="flex-basis: unset; width: 100%; margin-bottom: 4px" *ngIf="aboutService.isAdminEnabled">
     <button mat-button color="warn" class="admin-enabled-link" routerLink="/admin">Admin Enabled</button>
   </div>
   <div class="key">Stream Loading:</div>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -28,9 +28,9 @@
   <div class="value " style="flex-basis: unset; width: 100%;" *ngIf="aboutService.isAdminEnabled">
     <button mat-button color="warn" class="admin-enabled-link" routerLink="/admin">Admin Enabled</button>
   </div>
-  <!--<div class="key">Stream Loading:</div>
-  <div class="value" *ngIf="!aboutService.isAdminEnabled || !aboutService.isPocServerInstance">Disabled</div>
-  <div class="value" *ngIf="aboutService.isAdminEnabled && aboutService.isPocServerInstance">Enabled</div>-->
+  <div class="key">Stream Loading:</div>
+  <div class="value" *ngIf="!aboutService.isAdminEnabled || !aboutService.isPocServerInstance || !configService.isStreamingConfigured">Disabled</div>
+  <div class="value" *ngIf="aboutService.isAdminEnabled && aboutService.isPocServerInstance && configService.isStreamingConfigured">Enabled</div>
   <div class="key" style="flex-basis: auto; flex-grow: 2;">NAPI Version: </div>
   <div class="value" style="flex-basis: unset; width: 100%;">{{ aboutService.nativeApiVersion }}</div>
   <div class="native-group">NAPI Build # {{ aboutService.nativeApiBuildNumber }}</div>

--- a/src/app/about/about.component.html
+++ b/src/app/about/about.component.html
@@ -29,8 +29,8 @@
     <button mat-button color="warn" class="admin-enabled-link" routerLink="/admin">Admin Enabled</button>
   </div>
   <div class="key">Stream Loading:</div>
-  <div class="value" *ngIf="!aboutService.isAdminEnabled || !aboutService.isPocServerInstance || !configService.isStreamingConfigured">Disabled</div>
-  <div class="value" *ngIf="aboutService.isAdminEnabled && aboutService.isPocServerInstance && configService.isStreamingConfigured">Enabled</div>
+  <div class="value" *ngIf="!isStreamLoadingEnabled">Disabled</div>
+  <div class="value" *ngIf="isStreamLoadingEnabled">Enabled</div>
   <div class="key" style="flex-basis: auto; flex-grow: 2;">NAPI Version: </div>
   <div class="value" style="flex-basis: unset; width: 100%;">{{ aboutService.nativeApiVersion }}</div>
   <div class="native-group">NAPI Build # {{ aboutService.nativeApiBuildNumber }}</div>

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -1,4 +1,5 @@
 import { Component, AfterViewInit } from '@angular/core';
+import { SzWebAppConfigService } from '../services/config.service';
 import { AboutInfoService } from '../services/about.service';
 /**
  * a component to display dependency version info
@@ -13,7 +14,7 @@ import { AboutInfoService } from '../services/about.service';
   styleUrls: ['./about.component.scss']
 })
 export class AboutComponent implements AfterViewInit {
-  constructor(public aboutService: AboutInfoService) {}
+  constructor(public aboutService: AboutInfoService, public configService: SzWebAppConfigService) {}
 
   ngAfterViewInit() {}
 }

--- a/src/app/about/about.component.ts
+++ b/src/app/about/about.component.ts
@@ -14,6 +14,14 @@ import { AboutInfoService } from '../services/about.service';
   styleUrls: ['./about.component.scss']
 })
 export class AboutComponent implements AfterViewInit {
+  public get isStreamLoadingEnabled(): boolean {
+    let isEnabled = this.aboutService.isAdminEnabled && this.aboutService.isPocServerInstance && this.configService.isStreamingConfigured
+    if(isEnabled && !this.configService.loadQueueConfigured) {
+      isEnabled = false;
+    }
+    return isEnabled;
+  }
+
   constructor(public aboutService: AboutInfoService, public configService: SzWebAppConfigService) {}
 
   ngAfterViewInit() {}

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -240,6 +240,9 @@ export class SzWebAppConfigService {
     // directly since container is immutable and
     // doesnt write to file system.
     return this.http.get<POCStreamConfig | undefined>('./config/streams').pipe(
+      tap((resp) => {
+        console.log('streams config resp:', resp);
+      }),
       catchError((err) => {
         // return default payload for local developement when "/config/api" not available
         console.warn('streams returned undefined');
@@ -249,9 +252,6 @@ export class SzWebAppConfigService {
   }
   public getAppPackageInfo(): Observable<WebAppPackageInfo> {
     return this.http.get<WebAppPackageInfo>('./config/package').pipe(
-      tap((resp) => {
-        console.log('stream config resp:', resp);
-      }),
       catchError((err) => {
         // return default payload for local developement when "/config/package" not available
         return of({

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -140,14 +140,8 @@ export class SzWebAppConfigService {
       });
       // get updated stream config
       this.getRuntimeStreamConfig().pipe(
-        take(1),
-        catchError((err: Error) => {
-          console.log('could not get stream config. streaming not configured properly.');
-          this._isStreamingConfigured = false;
-          return of(err);
-        })
+        take(1)
       ).subscribe((resp: POCStreamConfig | Error) => {
-        if((resp as POCStreamConfig) && (resp as POCStreamConfig).target){
           this._isStreamingConfigured = true;
           this._pocStreamConfig = (resp as POCStreamConfig);
           if(this._pocStreamConfig && !this.loadQueueConfigured) {
@@ -155,7 +149,6 @@ export class SzWebAppConfigService {
           }
           this._onPocStreamConfigChange.next( this._pocStreamConfig );
           //console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
-        }
       });
       // get updated server info if api config has changed
       this.adminService.getServerInfo().pipe(take(1)).subscribe( (resp: SzServerInfo) => {
@@ -180,14 +173,9 @@ export class SzWebAppConfigService {
         filter(() => {
           return this.isPocServerInstance && this.isAdminEnabled;
         }),
-        take(1),
-        catchError((err: Error) => {
-          console.log('could not get stream config. streaming not configured properly.');
-          this._isStreamingConfigured = false;
-          return of(err);
-        })
-      ).subscribe((resp: POCStreamConfig | Error) => {
-        if((resp as POCStreamConfig) && (resp as POCStreamConfig).target){
+        take(1)
+      ).subscribe((resp: POCStreamConfig) => {
+        
           this._isStreamingConfigured = true;
           this._pocStreamConfig = (resp as POCStreamConfig);
           if(this._pocStreamConfig && !this.loadQueueConfigured) {
@@ -195,7 +183,6 @@ export class SzWebAppConfigService {
           }
           this._onPocStreamConfigChange.next( this._pocStreamConfig );
           console.warn('POC STREAM CONFIG! '+ this._isStreamingConfigured, this._pocStreamConfig);
-        }
       });
     });
 
@@ -263,22 +250,12 @@ export class SzWebAppConfigService {
       })
     );
   }
-  public getRuntimeStreamConfig(): Observable<POCStreamConfig | undefined | Error> {
+  public getRuntimeStreamConfig(): Observable<POCStreamConfig> {
     // reach out to webserver to get api
     // config. we cant do this with static files
     // directly since container is immutable and
     // doesnt write to file system.
-    return this.http.get<POCStreamConfig | undefined | Error>('./config/streams').pipe(
-      map((resp) => {
-        console.log('streams config resp:', resp);
-        if(!resp || resp === null){
-          throwError(undefined);
-          return Error(undefined)
-        } else {
-          return resp;
-        }
-      })
-    );
+    return this.http.get<POCStreamConfig>('./config/streams');
   }
   public getAppPackageInfo(): Observable<WebAppPackageInfo> {
     return this.http.get<WebAppPackageInfo>('./config/package').pipe(

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, Inject } from '@angular/core';
-import { BehaviorSubject, Observable, of, Subject, interval, from } from 'rxjs';
-import { catchError, filter, switchMap, take, tap } from 'rxjs/operators';
+import { BehaviorSubject, Observable, of, Subject, interval, from, throwError } from 'rxjs';
+import { catchError, filter, switchMap, map, take, tap } from 'rxjs/operators';
 import { SzAdminService, SzRestConfigurationParameters, SzConfigurationService, SzServerInfo, SzMeta } from '@senzing/sdk-components-ng';
 import { HttpClient } from '@angular/common/http';
 
@@ -29,7 +29,7 @@ export interface POCStreamConfig {
     protocol?: string;
     path?: string;
   }
-  target: string;
+  target?: string;
   protocol?: string;
 }
 export interface WebAppPackageInfo {
@@ -240,8 +240,13 @@ export class SzWebAppConfigService {
     // directly since container is immutable and
     // doesnt write to file system.
     return this.http.get<POCStreamConfig | undefined>('./config/streams').pipe(
-      tap((resp) => {
+      map((resp) => {
         console.log('streams config resp:', resp);
+        if(!resp || resp === null){
+          throwError(undefined);
+        } else {
+          return resp;
+        }
       }),
       catchError((err) => {
         // return default payload for local developement when "/config/api" not available

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -242,12 +242,16 @@ export class SzWebAppConfigService {
     return this.http.get<POCStreamConfig | undefined>('./config/streams').pipe(
       catchError((err) => {
         // return default payload for local developement when "/config/api" not available
+        console.warn('streams returned undefined');
         return of(undefined);
       })
     );
   }
   public getAppPackageInfo(): Observable<WebAppPackageInfo> {
     return this.http.get<WebAppPackageInfo>('./config/package').pipe(
+      tap((resp) => {
+        console.log('stream config resp:', resp);
+      }),
       catchError((err) => {
         // return default payload for local developement when "/config/package" not available
         return of({

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -140,7 +140,12 @@ export class SzWebAppConfigService {
       });
       // get updated stream config
       this.getRuntimeStreamConfig().pipe(
-        take(1)
+        take(1),
+        catchError((err: Error) => {
+          console.log('could not get stream config. streaming not configured properly.');
+          this._isStreamingConfigured = false;
+          return of(err);
+        })
       ).subscribe((resp: POCStreamConfig | Error) => {
         if((resp as POCStreamConfig) && (resp as POCStreamConfig).target){
           this._isStreamingConfigured = true;
@@ -272,11 +277,6 @@ export class SzWebAppConfigService {
         } else {
           return resp;
         }
-      }),
-      catchError((err) => {
-        // return default payload for local developement when "/config/api" not available
-        console.warn('streams returned undefined');
-        return of(undefined);
       })
     );
   }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -123,6 +123,16 @@ export class SzWebAppConfigService {
   ) {
 
     // ---------------------------------------  set up event handlers -------------------------------------------
+    
+    let onStreamConfigResponse = (resp: POCStreamConfig) => {
+      this._isStreamingConfigured = true;
+      this._pocStreamConfig = (resp as POCStreamConfig);
+      if(this._pocStreamConfig && !this.loadQueueConfigured) {
+        this._isStreamingConfigured = false;
+      }
+      this._onPocStreamConfigChange.next( this._pocStreamConfig );
+      console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
+    }
 
     // if the api config changes we need to grab a new versions of 
     // stream config and auth config
@@ -141,15 +151,7 @@ export class SzWebAppConfigService {
       // get updated stream config
       this.getRuntimeStreamConfig().pipe(
         take(1)
-      ).subscribe((resp: POCStreamConfig | Error) => {
-          this._isStreamingConfigured = true;
-          this._pocStreamConfig = (resp as POCStreamConfig);
-          if(this._pocStreamConfig && !this.loadQueueConfigured) {
-            this._isStreamingConfigured = false;
-          }
-          this._onPocStreamConfigChange.next( this._pocStreamConfig );
-          //console.warn('POC STREAM CONFIG!', this._pocStreamConfig);
-      });
+      ).subscribe(onStreamConfigResponse);
       // get updated server info if api config has changed
       this.adminService.getServerInfo().pipe(take(1)).subscribe( (resp: SzServerInfo) => {
         this._serverInfo = resp;
@@ -174,16 +176,7 @@ export class SzWebAppConfigService {
           return this.isPocServerInstance && this.isAdminEnabled;
         }),
         take(1)
-      ).subscribe((resp: POCStreamConfig) => {
-        
-          this._isStreamingConfigured = true;
-          this._pocStreamConfig = (resp as POCStreamConfig);
-          if(this._pocStreamConfig && !this.loadQueueConfigured) {
-            this._isStreamingConfigured = false;
-          }
-          this._onPocStreamConfigChange.next( this._pocStreamConfig );
-          console.warn('POC STREAM CONFIG! '+ this._isStreamingConfigured, this._pocStreamConfig);
-      });
+      ).subscribe(onStreamConfigResponse);
     });
 
     // -----------------------------------------  initial requests ---------------------------------------------

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -234,16 +234,17 @@ export class SzWebAppConfigService {
       })
     );
   }
-  public getRuntimeStreamConfig(): Observable<POCStreamConfig | undefined> {
+  public getRuntimeStreamConfig(): Observable<POCStreamConfig | undefined | Error> {
     // reach out to webserver to get api
     // config. we cant do this with static files
     // directly since container is immutable and
     // doesnt write to file system.
-    return this.http.get<POCStreamConfig | undefined>('./config/streams').pipe(
+    return this.http.get<POCStreamConfig | undefined | Error>('./config/streams').pipe(
       map((resp) => {
         console.log('streams config resp:', resp);
         if(!resp || resp === null){
           throwError(undefined);
+          return Error(undefined)
         } else {
           return resp;
         }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #235 
possibly resolves #233 

## Why was change needed

by default the application queries `/conf/package` for information about the application(dependency versions etc) if not configured properly no information will be available to display. (see screenshot)

by default the application queries `/conf/streams` for information about the ability of the pocServer to support SQS if not configured properly no information will be available and the application will not enable SQS.

## What does change improve

- Stream loading
- About box

## Screen Shots
![image](https://user-images.githubusercontent.com/13721038/147292496-54290dba-8485-4716-8b23-bd848f835cb5.png)

should now render as
![image](https://user-images.githubusercontent.com/13721038/147292537-0547a06d-12f3-448c-89c3-de9a6dc2fa46.png)
