### PR TITLE
#249 added console pop-out functionality

### DIFF
--- a/src/app/admin/admin-console/admin-console.component.html
+++ b/src/app/admin/admin-console/admin-console.component.html
@@ -7,4 +7,9 @@
     These were formerly known as the POC (Proof of Concept) utilities in prior Senzing versions.   We renamed them to EDA (Exploratory Data Analysis) tools because while they certainly help POCs they can be used long after to help ensure your system is performing as expected. 
     <a href="https://senzing.zendesk.com/hc/en-us/articles/360052040553-Exploratory-Data-Analysis-Overview-EDA-Tools-" target="_new">Click here</a> for more information on what each tool does and a brief walkthrough of functionality.
 </p>
-<sz-xterm #xtermConsole [class.taller]="!this.uiService.searchExpanded"></sz-xterm>
+<div *ngIf="!isConsolePoppedOut" class="xterm-rel-wrapper">
+    <mat-icon class="pop-out-icon" (click)="detachCmdFromPage()">open_in_new</mat-icon>
+    <button mat-button class="button-connect"    *ngIf="!isConnected && !isConsolePoppedOut" (click)="toggleConnection()"><mat-icon>link</mat-icon>Connect</button>
+    <!--<button mat-button class="button-disconnect" *ngIf="isConnected && !isConsolePoppedOut"  (click)="toggleConnection()"><mat-icon>link_off</mat-icon>Disconnect</button>-->
+    <sz-xterm #xtermConsole [class.taller]="!this.uiService.searchExpanded"></sz-xterm>
+</div>

--- a/src/app/admin/admin-console/admin-console.component.scss
+++ b/src/app/admin/admin-console/admin-console.component.scss
@@ -16,4 +16,27 @@
       height: calc(100vh - 240px);
     }
   }
+  .xterm-rel-wrapper {
+    position: relative;
+    .pop-out-icon {
+      position: absolute;
+      bottom: 25px;
+      right: 30px;
+      color: #fff;
+      z-index: 20;
+      cursor: pointer;
+    }
+    .button-connect,
+    .button-disconnect {
+      position: absolute;
+      bottom: 20px;
+      right: 60px;
+      z-index: 22;
+      cursor: pointer;
+      color: #fff;
+      .mat-icon {
+        margin-right: 8px;
+      }
+    }
+  }
 }

--- a/src/app/admin/admin-console/admin-console.component.ts
+++ b/src/app/admin/admin-console/admin-console.component.ts
@@ -16,19 +16,30 @@ export class AdminConsoleComponent implements AfterViewInit, OnDestroy {
   @ViewChild('xtermConsole')
   xtermConsole: XtermComponent;
 
+  private externalWindow = null;
+  private _extConsoleClosedCheckTimer;
+  private _externalWindowDefaultWidth = 1280;
+  private _externalWindowDefaultHeight  = 768;
+
   public get isConnected(): boolean {
     return this.xtermService.connected;
   }
+  public get isConsolePoppedOut(): boolean {
+    return this.uiService.consolePopOutOpen;
+  }
 
-  constructor( public uiService: UiService, private xtermService: SzXtermSocket) {}
+  constructor( private xtermService: SzXtermSocket, public uiService: UiService) {}
 
   ngAfterViewInit(): void {
     this.uiService.onSearchExpanded.pipe(
       takeUntil(this.unsubscribe$)
     ).subscribe((isExpanded: boolean) => {
       // call "fit()" in the xterm component when expansion state changes
-      console.log('search expansion state changed. calling "xtermConsole.fit()"..');
-      this.xtermConsole.fit();
+      if(this.xtermConsole && this.xtermConsole.fit) {
+        try {
+          this.xtermConsole.fit();
+        } catch(err){}
+      }
     });
   }
 
@@ -38,5 +49,35 @@ export class AdminConsoleComponent implements AfterViewInit, OnDestroy {
   ngOnDestroy() {
     this.unsubscribe$.next();
     this.unsubscribe$.complete();
+  }
+  public toggleConnection() {
+    if(this.xtermConsole && this.xtermConsole.refresh) {
+      console.log('toggleConnection: ', this.xtermConsole);
+      this.xtermConsole.refresh();
+    }
+  }
+  /** pop command window out of page */
+  public detachCmdFromPage() {
+    if(this.xtermConsole && this.xtermConsole.disconnect) {
+      console.log('disconnect socket from console');
+      this.xtermConsole.disconnect();
+    }
+
+    let _windowOpts = 'width='+ this._externalWindowDefaultWidth +',height='+this._externalWindowDefaultHeight+',left=200,top=200'
+    this.externalWindow = window.open('/no-decorator(popup:console)', '_szconsole', _windowOpts);
+    this.uiService.consolePopOutOpen = true;
+    this._extConsoleClosedCheckTimer = setInterval(() => {
+      if(this.externalWindow && this.externalWindow.closed){
+        clearInterval(this._extConsoleClosedCheckTimer);
+        this.uiService.consolePopOutOpen = false;
+        setTimeout(() => {
+          if(this.xtermConsole && this.xtermConsole.refresh) {
+            try {
+              this.xtermConsole.refresh()
+            } catch(err){}
+          }
+        }, 1000);
+      }
+    })
   }
 }

--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -26,6 +26,7 @@ import { AdminServerInfoComponent } from './server-info/server-info.component';
 import { AdminLicenseInfoComponent } from './license-info/license-info.component';
 import { AdminLoginComponent } from './login/login.component';
 import { AdminConsoleComponent } from './admin-console/admin-console.component';
+import { XtermComponent } from './xterm/xterm.component';
 
 /** injection token for external redirects */
 const externalUrlProvider = new InjectionToken('externalUrlRedirectResolver');
@@ -74,6 +75,7 @@ const routes: Routes = [
           },
           {
             path: 'console',
+            pathMatch: 'full',
             component: AdminConsoleComponent
           },
           {

--- a/src/app/admin/xterm/xterm.component.html
+++ b/src/app/admin/xterm/xterm.component.html
@@ -1,4 +1,4 @@
-<div class="xterm-wrapper">
+<div class="xterm-wrapper" [class.fullscreen]="_isFullScreen">
     <div *ngIf="!isConnected" class="xterm-console-shade" [class.xtermConsoleDisconnected]="!isConnected">
         <span class="xterm-console-shade-center">Disconnected</span>
     </div>

--- a/src/app/admin/xterm/xterm.component.scss
+++ b/src/app/admin/xterm/xterm.component.scss
@@ -24,6 +24,22 @@
         position: relative;
         width: calc(100vw - 220px - 80px);
         height: calc(100vh - 470px);
+        &.fullscreen {
+            width: calc(100vw - 0px) !important;
+            height: calc(100vh - 0px) !important;
+            .xterm-viewport, 
+            .xterm-screen,
+            .xterm-console-shade {
+                width: calc(100vw - 0px) !important;
+                height: calc(100vh - 0px) !important;
+            }
+            .xterm-console-shade {
+                width: calc(100vw - 0px) !important;
+            }
+            .xterm-screen {
+                margin: 0;
+            }
+        }
     }
     .xterm-console-shade {
         position: absolute;
@@ -49,4 +65,19 @@
         width: 100%;
         height: 100%;
     }
+    
+    /* I have no idea why but this doesnt work
+       maybe something to do with ShadowDom 
+    */
+    /*
+    &.fullscreen {
+        border: 2px dashed darkblue;
+        .xterm-viewport, 
+        .xterm-screen,
+        .xterm-wrapper,
+        .xterm-console-shade {
+            width: 100vw !important;
+            height: 100vh !important;
+        }
+    }*/
 }

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -20,8 +20,11 @@ import { GatewayTimeoutErrorComponent } from './errors/timeout/timeout.component
 import { UnknownErrorComponent } from './errors/uknown/uknown.component';
 import { AboutComponent } from './about/about.component';
 import { BlankComponent } from './common/blank/blank.component';
+import { XtermComponent } from './admin/xterm/xterm.component';
+import { NoDecorationComponent } from './common/no-decoration/no-decoration.component';
 
 export const routes: Routes = [
+  { path: 'no-decorator', component: NoDecorationComponent},
   { path: 'debug', component: BlankComponent},
   { path: 'search', component: TipsComponent, resolve:  {entityId: CurrentEntityUnResolverService}, data: { animation: 'search-results' }},
   { path: 'search/results', component: SearchResultsComponent, resolve: { params: SearchParamsResolverService, results: SearchResultsResolverService }, data: { animation: 'search-results' } },
@@ -35,6 +38,12 @@ export const routes: Routes = [
   { path: 'errors/504', component: GatewayTimeoutErrorComponent, data: { animation: 'search-detail' } },
   { path: 'errors/unknown', component: UnknownErrorComponent, data: { animation: 'search-detail' } },
   { path: 'about', component: AboutComponent, data: { animation: 'search-detail'} },
+  {
+    path: 'console',
+    outlet: 'popup',
+    component: XtermComponent,
+    data: { fullscreen: true }
+  },
   { path: '',   redirectTo: 'search', pathMatch: 'full' },
   { path: '**', component: PageNotFoundComponent }
 ];

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,7 +1,10 @@
-<app-toolbar
+<app-toolbar *ngIf="!noDecoration"
   (showSection)="onToolBarSectionChange($event)"
   [prefsIsShowing]="showPrefs"></app-toolbar>
-<div class="tool-tray" [class.expanded]="searchExpanded" [class.graph-open]="isGraphOpen" [class.prefs-showing]="showPrefs">
+<div *ngIf="!noDecoration" class="tool-tray" 
+  [class.expanded]="searchExpanded" 
+  [class.graph-open]="isGraphOpen" 
+  [class.prefs-showing]="showPrefs">
     <div id="toolbar-col1" class="column">
       <sz-preferences *ngIf="showPrefs"
         showControls="true"></sz-preferences>
@@ -55,7 +58,9 @@
     <mat-icon (click)="toggleRibbonState($event)"*ngIf="searchExpanded && !showPrefs" class="toggle-icon">expand_less</mat-icon>
 </div>
 <app-spinner></app-spinner>
-<div class="view-primary" [class.expanded]="!this.uiService.searchExpanded" [@routeAnimation]="getAnimationData(routerOutlet)">
+<div *ngIf="!noDecoration" class="view-primary" [class.expanded]="!this.uiService.searchExpanded" [@routeAnimation]="getAnimationData(routerOutlet)">
   <router-outlet #routerOutlet="outlet"></router-outlet>
 </div>
-<router-outlet name="popup"></router-outlet>
+<div *ngIf="noDecoration" class="popup-wrapper">
+  <router-outlet name="popup"></router-outlet>
+</div>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -6,6 +6,13 @@ sz-powered-by {
   position: absolute;
 }
 
+/* pop-ups use a different router-outlet 
+ * inside the top-level AppComponent. 
+ * Other elements are hidden.
+ */
+.popup-wrapper {
+  display: block;
+}
 
 .tool-tray {
   display: flex;
@@ -146,7 +153,7 @@ sz-powered-by {
     height: unset;
   }
 }
-:host.layout-super-narrow, {
+:host.layout-super-narrow {
   .tool-tray.expanded {
     height: 520px;
   }
@@ -154,8 +161,7 @@ sz-powered-by {
     height: unset;
   }
 }
-:host.layout-medium, {
-
+:host.layout-medium {
   .tool-tray.expanded.prefs-showing {
     height: unset;
   }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -6,13 +6,6 @@ sz-powered-by {
   position: absolute;
 }
 
-/* pop-ups use a different router-outlet 
- * inside the top-level AppComponent. 
- * Other elements are hidden.
- */
-.popup-wrapper {
-  display: block;
-}
 
 .tool-tray {
   display: flex;
@@ -178,6 +171,14 @@ app-spinner {
   &.expanded {
       height: calc(100vh - 116px);
   }
+}
+
+/* pop-ups use a different router-outlet 
+ * inside the top-level AppComponent. 
+ * Other elements are hidden.
+ */
+ .popup-wrapper {
+  display: block;
 }
 
 // spinner animations

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -53,6 +53,9 @@ export class AppComponent implements OnInit, OnDestroy {
       return 'memory';
     }
   }
+  public get noDecoration(): boolean {
+    return this.uiService.noDecoration;
+  }
 
   /** subscription to notify subscribers to unbind */
   public unsubscribe$ = new Subject<void>();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { UiService } from './services/ui.service';
 import { PrefsManagerService } from './services/prefs-manager.service';
 import { TipsComponent } from './common/tips/tips.component';
 import { BlankComponent } from './common/blank/blank.component';
+import { NoDecorationComponent } from './common/no-decoration/no-decoration.component';
 import { NoResultsComponent } from './errors/no-results/no-results.component';
 import { AboutComponent } from './about/about.component';
 
@@ -83,6 +84,7 @@ import { AdminBulkDataService } from './services/admin.bulk-data.service';
     ToolbarComponent,
     ErrorPageComponent,
     PageNotFoundComponent,
+    NoDecorationComponent,
     NoResultsComponent,
     GatewayTimeoutErrorComponent,
     ServerErrorComponent,

--- a/src/app/common/no-decoration/no-decoration.component.html
+++ b/src/app/common/no-decoration/no-decoration.component.html
@@ -1,0 +1,1 @@
+<!-- no-decoration.component -->

--- a/src/app/common/no-decoration/no-decoration.component.ts
+++ b/src/app/common/no-decoration/no-decoration.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-no-decoration',
+  templateUrl: './no-decoration.component.html',
+  styleUrls: ['./no-decoration.component.scss']
+})
+export class NoDecorationComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/services/ui.service.ts
+++ b/src/app/services/ui.service.ts
@@ -7,11 +7,13 @@ import { Router, ActivatedRoute, UrlSegment, NavigationEnd } from '@angular/rout
   providedIn: 'root'
 })
 export class UiService {
-  private _searchExpanded = true;
-  private _searchType = 'default';
-  public createPdfClicked = new Subject<number>();
-  private _graphOpen = false;
-  private _resultsViewType = 'default';
+  private _searchExpanded     = true;
+  private _searchType         = 'default';
+  public createPdfClicked     = new Subject<number>();
+  private _graphOpen          = false;
+  private _noDecoration       = false;
+  private _consolePopOutOpen  = false;
+  private _resultsViewType    = 'default';
   /** when the search tray expansion state changes */
   private _onSearchExpanded: BehaviorSubject<boolean>   = new BehaviorSubject<boolean>(this._searchExpanded);
   /** delay the observeable by time of tray animation */
@@ -38,7 +40,15 @@ export class UiService {
   public set resultsViewType(value: string) {
     this._resultsViewType = value;
   }
-
+  public get noDecoration(): boolean {
+    return this._noDecoration;
+  }
+  public get consolePopOutOpen(): boolean {
+    return this._consolePopOutOpen;
+  }
+  public set consolePopOutOpen(value: boolean) {
+    this._consolePopOutOpen = value;
+  }
   public get graphOpen(): boolean {
     return this._graphOpen;
   }
@@ -73,11 +83,15 @@ export class UiService {
     // because there is also an embedded graph
     route.url.subscribe( (url: UrlSegment[]) => {
       const urlStr = url.join();
-      this._graphOpen = (urlStr && urlStr.indexOf && urlStr.indexOf('/graph/') >= 0);
+      this._graphOpen         = (urlStr && urlStr.indexOf && urlStr.indexOf('/graph/') >= 0);
+      this._noDecoration      = (urlStr && urlStr.indexOf && urlStr.indexOf('/no-decorator') >= 0);
+      //this._consolePopOutOpen = (urlStr && urlStr.indexOf && urlStr.indexOf('/no-decorator(popup:console)') >= 0);
     });
     router.events.subscribe((event) => {
       if (event instanceof NavigationEnd ) {
-        this._graphOpen = (event && event.urlAfterRedirects && event.urlAfterRedirects.indexOf('/graph/') >= 0);
+        this._graphOpen         = (event && event.urlAfterRedirects && event.urlAfterRedirects.indexOf('/graph/') >= 0);
+        this._noDecoration      = (event && event.urlAfterRedirects && event.urlAfterRedirects.indexOf('/no-decorator') >= 0);
+        //this._consolePopOutOpen = (event && event.urlAfterRedirects && event.urlAfterRedirects.indexOf('/no-decorator(popup:console)') >= 0);
       }
     });
   }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #249 

## Why was change needed

@jbutcher21 requested the ability to pop the console out of the page. seemed reasonable.

## What does change improve

![image](https://user-images.githubusercontent.com/13721038/151651563-ba04d8ac-3a29-46af-94b3-ce06973eb7f4.png)

![image](https://user-images.githubusercontent.com/13721038/151651510-d2f50d8f-c685-4896-bab8-28797458d7eb.png)

console can be operated separately from the main window. when #250 is fully implemented the user should be able to click on urls in the eda tools and have them open up in the main window or separate windows.
