### PR TITLE
#252 json files now use onChunkRead instead of onRecordRead

### DIFF
--- a/src/app/graph/graph.component.scss
+++ b/src/app/graph/graph.component.scss
@@ -77,7 +77,7 @@
       padding-top: 16px;
     }
 
-    sz-entity-detail-graph-filter {
+    sz-entity-detail-graph-filter, sz-graph-filter {
       margin-left: 20px;
       display: block;
       color: #6b6666;

--- a/src/app/services/admin.bulk-data.service.ts
+++ b/src/app/services/admin.bulk-data.service.ts
@@ -788,7 +788,7 @@ export class AdminBulkDataService {
         if(fileType === validImportFileTypes.CSV) {
             return this.streamAnalyzeByChunks(file);
         } else if(fileType === validImportFileTypes.JSON || fileType === validImportFileTypes.JSONL) {
-            return this.streamAnalyzeByRecords(file);
+            return this.streamAnalyzeByChunks(file);
         }
     }
 
@@ -1158,7 +1158,7 @@ export class AdminBulkDataService {
         if(fileType === validImportFileTypes.CSV) {
             return this.streamLoadByChunks(file, dataSourceMap, entityTypeMap);
         } else if(fileType === validImportFileTypes.JSON || fileType === validImportFileTypes.JSONL) {
-            return this.streamLoadByRecords(file, dataSourceMap, entityTypeMap);
+            return this.streamLoadByChunks(file, dataSourceMap, entityTypeMap);
         }
     }
 

--- a/src/app/workers/stream-reader.worker.ts
+++ b/src/app/workers/stream-reader.worker.ts
@@ -68,16 +68,14 @@ addEventListener('message', ({ data }) => {
     if(fileType === validImportFileTypes.JSONL || fileType === validImportFileTypes.JSON) { 
         let recordsReadFromStream = [];
 
-        console.log(`StreamReaderWorker.onMessage: reading ${fileName}`);
-        //postMessage(_readRecords);
-        
-        getRecordsFromFileStream(file, reader, summary).subscribe((records: string[]) => {
+        console.log(`StreamReaderWorker.onMessage: reading json/json-lines ${fileName}`);
+        getChunksFromFileStream(file, reader, summary).subscribe((chunk: string) => {
             // records read from stream read
-            //_readRecords = records;
-            postMessage(records);
+            _readChunks = _readChunks.concat(chunk);
+            postMessage(chunk);
             //summary.recordCount = _readRecords.length;
             //this.onLoadResult.next( summary );
-            //console.log(`StreamReaderWorker.onRecordRead() read ${_readRecords.length} records`);
+            console.log(`StreamReaderWorker.onChunkRead() read ${_readChunks.length} chunks`);
         });
 
         //return retStreamSummary;


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #252 

## Why was change needed

`json-lines` file loading was using older method of pre-parsing data before sending it to poc-server which was resulting in messages per-record with no newline char at the end of the message which the poc server would not correctly parse.

## What does change improve

json-lines file loading

![image](https://user-images.githubusercontent.com/13721038/153498610-30d0a9ab-e0a0-4ed4-af65-b7f356a2fc3a.png)
