### PR TITLE
update Dockerfile FROM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BUILD_IMAGE=node:16-bullseye-slim
-ARG PROD_IMAGE=node:16-alpine-3.15
+ARG PROD_IMAGE=node:16-alpine3.15
 ARG TEST_IMAGE=node:16-bullseye-slim
 
 FROM ${BUILD_IMAGE}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-ARG BUILD_IMAGE=node:14-buster-slim
-ARG PROD_IMAGE=node:lts-alpine
-ARG TEST_IMAGE=node:14-buster-slim
+ARG BUILD_IMAGE=node:16-bullseye-slim
+ARG PROD_IMAGE=node:16-alpine-3.15
+ARG TEST_IMAGE=node:16-bullseye-slim
 
 FROM ${BUILD_IMAGE}
 ENV REFRESHED_AT=2022-05-09


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #282 

## Why was change needed

the auto update script seems to fumble when the `Dockerfile` in the repo has a multi-stage build using different images for different stages. Also the base is a [`nodejs` baseimage](https://hub.docker.com/_/node), not the regular debian image(s). `Dockerfile` updated to newer 11.x debian images.

## What does change improve

`BUILD_IMAGE` updated to `node:16-bullseye-slim`
`PROD_IMAGE` updated to `node:16-alpine3.15`
`TEST_IMAGE` updated to `node:16-bullseye-slim`
