### PR TITLE
Add reverse socket.io proxy to webapp configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,11 @@ ARG PROD_IMAGE=node:16-alpine3.15
 ARG TEST_IMAGE=node:16-bullseye-slim
 
 FROM ${BUILD_IMAGE}
-ENV REFRESHED_AT=2022-05-09
+ENV REFRESHED_AT=2022-05-22
 
 LABEL Name="senzing/entity-search-web-app" \
       Maintainer="support@senzing.com" \
-      Version="2.6.0"
+      Version="2.6.1"
 
 HEALTHCHECK CMD ["/app/healthcheck.sh"]
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senzing/entity-search-web-app",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -1,6 +1,6 @@
 //const { calcProjectFileAndBasePath } = require("@angular/compiler-cli");
 const { env } = require("process");
-const { getHostnameFromUrl, getPortFromUrl, getProtocolFromUrl, getRootFromUrl, replaceProtocol, getPathFromUrl } = require("./utils");
+const { getHostnameFromUrl, getPortFromUrl, getProtocolFromUrl, getRootFromUrl, replaceProtocol, replacePortNumber, getPathFromUrl } = require("./utils");
 
 function getCommandLineArgsAsJSON() {
   // grab cmdline args
@@ -439,7 +439,7 @@ function getConsoleServerOptionsFromInput() {
       retOpts.url       = env.SENZING_CONSOLE_SERVER_URL? env.SENZING_CONSOLE_SERVER_URL : retOpts.url;
       retOpts.enabled   = true;
       // set up reverse proxy
-      retOpts.url = webServerCfg.url +'/console'
+      retOpts.url = replacePortNumber(8273, webServerCfg.url)
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
@@ -458,7 +458,7 @@ function getConsoleServerOptionsFromInput() {
       retOpts.enabled   = true;
     }
     if(cmdLineOpts.consoleServerUrl) {
-      retOpts.url = webServerCfg.url +'/console'
+      retOpts.url = replacePortNumber(8273, webServerCfg.url);
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -446,8 +446,6 @@ function getConsoleServerOptionsFromInput() {
         // reassign to 8273
         retOpts.port    = 8273;
       }
-      // change url to a "local" address
-      retOpts.url = replacePortNumber(retOpts.port, webServerCfg.url)
       // and reassign url to proxy dest
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
@@ -455,6 +453,8 @@ function getConsoleServerOptionsFromInput() {
         target: env.SENZING_CONSOLE_SERVER_URL,
         port: env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : 8273
       }
+      // change url to a "local" address
+      retOpts.url = replaceProtocol(retOpts.protocol || (retOpts.proxy ? retOpts.proxy.protocol : false) || 'ws', replacePortNumber(retOpts.port, webServerCfg.url));
     }
   }
   let cmdLineOpts = getCommandLineArgsAsJSON();

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -479,8 +479,6 @@ function getConsoleServerOptionsFromInput() {
         port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8273
       }
     }
-    //console.log('------------ the fuck? ');
-    //console.log(cmdLineOpts);
   }
   return retOpts;
 }

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -469,8 +469,6 @@ function getConsoleServerOptionsFromInput() {
         // reassign to 8273
         retOpts.port    = 8273;
       }
-      // change url to a "local" address
-      retOpts.url = replacePortNumber(retOpts.port, webServerCfg.url);
       // and reassign url to proxy dest
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
@@ -478,6 +476,8 @@ function getConsoleServerOptionsFromInput() {
         target: cmdLineOpts.consoleServerUrl,
         port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8273
       }
+      // change url to a "local" address
+      retOpts.url = replaceProtocol(retOpts.protocol || (retOpts.proxy ? retOpts.proxy.protocol : false) || 'ws', replacePortNumber(retOpts.port, webServerCfg.url));
     }
   }
   return retOpts;

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -451,7 +451,7 @@ function getConsoleServerOptionsFromInput() {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
         target: env.SENZING_CONSOLE_SERVER_URL,
-        port: retOpts.port
+        port: env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : 8273
       }
     }
   }
@@ -475,7 +475,7 @@ function getConsoleServerOptionsFromInput() {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
         target: cmdLineOpts.consoleServerUrl,
-        port: 8273
+        port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8273
       }
     }
     //console.log('------------ the fuck? ');

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -439,7 +439,14 @@ function getConsoleServerOptionsFromInput() {
       retOpts.url       = env.SENZING_CONSOLE_SERVER_URL? env.SENZING_CONSOLE_SERVER_URL : retOpts.url;
       retOpts.enabled   = true;
       // set up reverse proxy
-      retOpts.url = replacePortNumber(8273, webServerCfg.url)
+      if(retOpts.port === webServerCfg.port){
+        // socket proxy cannot be on same port as web server
+        // reassign to 8273
+        retOpts.port    = 8273;
+      }
+      // change url to a "local" address
+      retOpts.url = replacePortNumber(retOpts.port, webServerCfg.url)
+      // and reassign url to proxy dest
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
@@ -456,9 +463,14 @@ function getConsoleServerOptionsFromInput() {
       retOpts.url       = cmdLineOpts.consoleServerUrl ?      cmdLineOpts.consoleServerUrl : retOpts.url;
       retOpts.port      = getPortFromUrl(retOpts.url);
       retOpts.enabled   = true;
-    }
-    if(cmdLineOpts.consoleServerUrl) {
-      retOpts.url = replacePortNumber(8273, webServerCfg.url);
+      if(retOpts.port === webServerCfg.port){
+        // socket proxy cannot be on same port as web server
+        // reassign to 8273
+        retOpts.port    = 8273;
+      }
+      // change url to a "local" address
+      retOpts.url = replacePortNumber(retOpts.port, webServerCfg.url);
+      // and reassign url to proxy dest
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -431,12 +431,21 @@ function getConsoleServerOptionsFromInput() {
       reconnectionDelay: 10000
     }
   }
+  let webServerCfg = getWebServerOptionsFromInput();
   if(env){
     retOpts.port        = env.SENZING_WEB_SERVER_PORT ? env.SENZING_WEB_SERVER_PORT   : retOpts.port;
     retOpts.port        = env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : retOpts.port;
     if(env.SENZING_CONSOLE_SERVER_URL) {
       retOpts.url       = env.SENZING_CONSOLE_SERVER_URL? env.SENZING_CONSOLE_SERVER_URL : retOpts.url;
       retOpts.enabled   = true;
+      // set up reverse proxy
+      retOpts.url = webServerCfg.url +'/console'
+      retOpts.proxy = {
+        protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
+        hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
+        target: env.SENZING_CONSOLE_SERVER_URL,
+        port: retOpts.port
+      }
     }
   }
   let cmdLineOpts = getCommandLineArgsAsJSON();
@@ -448,6 +457,17 @@ function getConsoleServerOptionsFromInput() {
       retOpts.port      = getPortFromUrl(retOpts.url);
       retOpts.enabled   = true;
     }
+    if(cmdLineOpts.consoleServerUrl) {
+      retOpts.url = webServerCfg.url +'/console'
+      retOpts.proxy = {
+        protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
+        hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
+        target: cmdLineOpts.consoleServerUrl,
+        port: 8273
+      }
+    }
+    //console.log('------------ the fuck? ');
+    //console.log(cmdLineOpts);
   }
   return retOpts;
 }

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -236,7 +236,6 @@ function createCspConfigFromInput() {
   // ------------- add console stream socket to connect src
   if( consoleCfg && consoleCfg.enabled && consoleCfg.url ) {
     let consoleUrl = replaceProtocol(consoleCfg.protocol, consoleCfg.url);
-    console.log('------------------------ CSP for console:  ', consoleUrl, consoleCfg);
     retConfig.directives['connect-src'].push(consoleUrl);
     retConfig.directives['connect-src'].push( getRootFromUrl( consoleUrl ) );
   }

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -235,8 +235,10 @@ function createCspConfigFromInput() {
   }
   // ------------- add console stream socket to connect src
   if( consoleCfg && consoleCfg.enabled && consoleCfg.url ) {
-    retConfig.directives['connect-src'].push(consoleCfg.url);
-    retConfig.directives['connect-src'].push( getRootFromUrl( consoleCfg.url ) );
+    let consoleUrl = replaceProtocol(consoleCfg.protocol, consoleCfg.url);
+    console.log('------------------------ CSP for console:  ', consoleUrl, consoleCfg);
+    retConfig.directives['connect-src'].push(consoleUrl);
+    retConfig.directives['connect-src'].push( getRootFromUrl( consoleUrl ) );
   }
 
   return retConfig;
@@ -439,7 +441,7 @@ function getConsoleServerOptionsFromInput() {
       retOpts.url       = env.SENZING_CONSOLE_SERVER_URL? env.SENZING_CONSOLE_SERVER_URL : retOpts.url;
       retOpts.enabled   = true;
       // set up reverse proxy
-      if(retOpts.port === webServerCfg.port){
+      if(retOpts.port == webServerCfg.port){
         // socket proxy cannot be on same port as web server
         // reassign to 8273
         retOpts.port    = 8273;
@@ -463,7 +465,7 @@ function getConsoleServerOptionsFromInput() {
       retOpts.url       = cmdLineOpts.consoleServerUrl ?      cmdLineOpts.consoleServerUrl : retOpts.url;
       retOpts.port      = getPortFromUrl(retOpts.url);
       retOpts.enabled   = true;
-      if(retOpts.port === webServerCfg.port){
+      if(retOpts.port == webServerCfg.port){
         // socket proxy cannot be on same port as web server
         // reassign to 8273
         retOpts.port    = 8273;

--- a/run/utils.js
+++ b/run/utils.js
@@ -60,6 +60,7 @@ let getProtocolFromUrl = function(url) {
 
 let replaceProtocol = function(protoStr, url) {
     if(!url) return;
+    if(!protoStr) return url; 
     if( url ) {
         if(url.indexOf && url.indexOf('://') > -1) {
             let urlTokened = url.split('://');

--- a/run/utils.js
+++ b/run/utils.js
@@ -92,7 +92,7 @@ let replacePortNumber = function(portNumber, url) {
             } else {
                 replToken = portNumber;
             }
-            console.log('replacePortNumber: ',urlTokened[replInd], replInd, urlTokened);
+            //console.log('replacePortNumber: ',urlTokened[replInd], replInd, urlTokened);
 
             urlTokened[( replInd )] = replToken;
             url = urlTokened.join(':');

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -437,7 +437,7 @@ if(consoleOptions && consoleOptions.enabled) {
           ws: true 
         });
         console_proxy.listen(consoleOptions.port || 8273, () => {
-          console.log(`WS Console Reverse Proxy Server started on port ${consoleOptions.proxy.port}\nforwarding to ${consoleOptions.proxy.target} :)`);
+          console.log(`[started] WS Console Reverse Proxy Server started on port ${(consoleOptions.port || 8273)}. Forwarding to ${consoleOptions.proxy.target} :)`);
           resolve();
         });
       } else {

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -419,6 +419,13 @@ let VIEW_VARIABLES = {
   ) ? (runtimeOptions.config.web.path + '/') : runtimeOptions.config.web.path,
   "VIEW_CSP_DIRECTIVES":""
 }
+
+// set up server(s) instance(s)
+var ExpressSrvInstance;
+var WebSocketProxyInstance;
+var StartupPromises = [];
+
+// set up xterm console reverse proxy (if enabled)
 if(consoleOptions && consoleOptions.enabled) {
   // add socket-io reverse proxy for xterm communication
   let setupConsoleServerProxy = new Promise((resolve) => {
@@ -477,10 +484,6 @@ app.get('*', (req, res) => {
   res.render('index', VIEW_VARIABLES);
 });
 
-// set up server(s) instance(s)
-var ExpressSrvInstance;
-var WebSocketProxyInstance;
-var StartupPromises = [];
 if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
   // https
   const ssl_opts = {

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -428,7 +428,7 @@ var StartupPromises = [];
 // set up xterm console reverse proxy (if enabled)
 if(consoleOptions && consoleOptions.enabled) {
   // add socket-io reverse proxy for xterm communication
-  let setupConsoleServerProxy = new Promise((resolve) => {
+  let consoleServerPromise = new Promise((resolve) => {
     let setupConsoleReverseProxy = function(streamOptions) {
       if(consoleOptions && consoleOptions.proxy) {
         // if user wants to proxy localhost to 

--- a/run/websocket-proxy/index.js
+++ b/run/websocket-proxy/index.js
@@ -11,7 +11,10 @@ const inMemoryConfigFromInputs = require('../runtime.datastore.config');
 
 const runtimeOptions = new inMemoryConfig(inMemoryConfigFromInputs);
 runtimeOptions.on('initialized', () => {
-    const streamOptions = runtimeOptions.config.stream;    
+    const streamOptions     = runtimeOptions.config.stream;
+    const consoleOptions    = runtimeOptions.config.console;
+    console.log('--------------- CONSOLE OPTIONS ---------------');
+    console.log(consoleOptions);
 
     if(streamOptions) {
         // create a server
@@ -30,6 +33,16 @@ runtimeOptions.on('initialized', () => {
         proxy.on('error', (err) => {
             console.log('-- WS ERROR: '+ err.message) +' --';
         })
+    }
+    if(consoleOptions && consoleOptions.proxy) {
+        // if user wants to proxy localhost to 
+        var console_proxy   = httpProxy.createServer({ 
+            target: consoleOptions.proxy.target,
+            ws: true 
+        });
+        console_proxy.listen(consoleOptions.port, () => {
+            console.log(`WS Console Proxy Server started on port ${consoleOptions.proxy.port}\nforwarding to ${consoleOptions.proxy.target} :)`);
+        });
     }
 
     if(streamOptions && streamOptions.proxy) {

--- a/run/websocket-proxy/index.js
+++ b/run/websocket-proxy/index.js
@@ -41,7 +41,7 @@ runtimeOptions.on('initialized', () => {
             ws: true 
         });
         console_proxy.listen(consoleOptions.port, () => {
-            console.log(`WS Console Proxy Server started on port ${consoleOptions.proxy.port}\nforwarding to ${consoleOptions.proxy.target} :)`);
+            console.log(`WS Console Proxy Server started on port ${consoleOptions.port}\nforwarding to ${consoleOptions.proxy.target} :)`);
         });
     }
 

--- a/run/websocket-proxy/index.js
+++ b/run/websocket-proxy/index.js
@@ -13,8 +13,8 @@ const runtimeOptions = new inMemoryConfig(inMemoryConfigFromInputs);
 runtimeOptions.on('initialized', () => {
     const streamOptions     = runtimeOptions.config.stream;
     const consoleOptions    = runtimeOptions.config.console;
-    console.log('--------------- CONSOLE OPTIONS ---------------');
-    console.log(consoleOptions);
+    //console.log('--------------- CONSOLE OPTIONS ---------------');
+    //console.log(consoleOptions);
 
     if(streamOptions) {
         // create a server


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #285 

## Why was change needed

To allow docker formations to not specify a publicly available FQDN. With a reverse proxy in place the docker config can just specify the container network name, and the client can just reference **_localhost with a different port_** that forwards the socket to the console server network url(if enabled)

This simplifies adding the `senzing/entity-search-web-app-console` docker container to the `docker-compose-demo` examples since it will no longer require knowledge of the specific FQDN address.

## What does change improve

With this change the docker formation yaml can just specify a variable pointing to the *local* name of the console container image. ie:
![image](https://user-images.githubusercontent.com/13721038/168190778-b31e9891-7902-423b-af77-98ec05ab1a72.png)


