### PR TITLE
285.awinters.2

### DIFF
--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -449,7 +449,7 @@ function getConsoleServerOptionsFromInput() {
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
-        target: env.SENZING_CONSOLE_SERVER_URL,
+        target: replaceProtocol((getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'), env.SENZING_CONSOLE_SERVER_URL),
         port: env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : 8273
       }
       // change url to a "local" address
@@ -473,7 +473,7 @@ function getConsoleServerOptionsFromInput() {
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
-        target: cmdLineOpts.consoleServerUrl,
+        target: replaceProtocol((getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'), cmdLineOpts.consoleServerUrl),
         port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8273
       }
       // change url to a "local" address

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -436,6 +436,9 @@ if(consoleOptions && consoleOptions.enabled) {
           target: consoleOptions.proxy.target,
           ws: true 
         });
+        console_proxy.on('error', (err) => {
+          console.log('[error] WS Console Reverse Proxy Server: ', err);
+        });
         console_proxy.listen(consoleOptions.port || 8273, () => {
           console.log(`[started] WS Console Reverse Proxy Server started on port ${(consoleOptions.port || 8273)}. Forwarding to ${consoleOptions.proxy.target} :)`);
           resolve();
@@ -521,6 +524,9 @@ if( serverOptions && serverOptions.ssl && serverOptions.ssl.enabled ){
             req.url = req.url;
           }
           proxy.ws(req, socket, head);
+        });
+        wsProxy.on('error', (err) => {
+          console.log('[error] WS Proxy Server: ', err);
         });
         wsProxy.listen(streamOptions.proxy.port || 8255, () => {
           console.log('[started] WS Proxy Server on port '+ (streamOptions.proxy.port || 8255) +'. Forwarding to "'+ streamOptions.target +'"');

--- a/run/websocket-proxy/index.js
+++ b/run/websocket-proxy/index.js
@@ -40,6 +40,9 @@ runtimeOptions.on('initialized', () => {
             target: consoleOptions.proxy.target,
             ws: true 
         });
+        console_proxy.on('error', (err) => {
+            console.log('-- WS CONSOLE ERROR: '+ err.message) +' --';
+        });
         console_proxy.listen(consoleOptions.port, () => {
             console.log(`WS Console Proxy Server started on port ${consoleOptions.port}\nforwarding to ${consoleOptions.proxy.target} :)`);
         });

--- a/src/app/common/url-utilities.ts
+++ b/src/app/common/url-utilities.ts
@@ -28,12 +28,8 @@ export function getProtocolFromUrl(url: string) {
 export function getBasePathFromUrl(url: string) {
     if(!url) return;
     if( url ) {
-        let _path    = getPathFromUrl(url);
-        if(_path) {
-            // remove path string from url
-            url = url.replace(_path, "");
-        }
-        return url;
+        let oUrl        = new URL(url);
+        return oUrl.origin;
     }
 }
 

--- a/src/app/common/url-utilities.ts
+++ b/src/app/common/url-utilities.ts
@@ -1,46 +1,17 @@
 export function getHostnameFromUrl(url: string) {
     if(!url) return;
     if(url) {
-        var hostname  = url;
-        if(hostname.indexOf && hostname.indexOf('://') > -1) {
-            // strip protocol off
-            let urlTokened = hostname.split('://');
-            hostname  = urlTokened[1];
-        }
-        if(hostname.indexOf && hostname.indexOf(':') > -1) {
-            // strip port off
-            let _ntemp = hostname.split(':')[0];
-            hostname = _ntemp;
-        }
-        if(hostname.indexOf && hostname.indexOf('/') > -1){
-            // strip off anything in path
-            let _ntemp = hostname.split('/')[0];
-            hostname = _ntemp;
-        }
-        //console.log(`set hostname to: "${hostname}"`);
-
-        return hostname;
+        let oUrl        = new URL(url);
+        return oUrl.hostname;
     }
     return;
 }
 
-export function getPortFromUrl(url: string) {
+export function getPortFromUrl(url: string): number {
     if(!url) return;
     if(url) {
-        var hostname    = url;
-        let portnumber  = 8250;
-        if(hostname.indexOf && hostname.indexOf('://') > -1) {
-            // strip protocol off
-            let urlTokened = hostname.split('://');
-            hostname  = urlTokened[1];
-        }
-        if(hostname.indexOf(':') > -1) {
-            // keep port
-            let _ntemp = hostname.split(':');
-            if(_ntemp.length > 1 && _ntemp[1]) {
-                portnumber    = parseInt(_ntemp[1]);
-            }
-        }
+        let oUrl        = new URL(url);
+        let portnumber  = oUrl.port ? parseInt(oUrl.port) : 8250;
         return portnumber;
     }
 }
@@ -48,11 +19,8 @@ export function getPortFromUrl(url: string) {
 export function getProtocolFromUrl(url: string) {
     if(!url) return;
     if( url ) {
-        let protocol    = 'http';
-        if(url.indexOf && url.indexOf('://') > -1) {
-            let urlTokened = url.split('://');
-            protocol  = urlTokened[0];
-        }
+        let oUrl        = new URL(url);
+        let protocol    = oUrl.protocol ? oUrl.protocol : 'http';
         return protocol;
     }
 }
@@ -72,19 +40,37 @@ export function getBasePathFromUrl(url: string) {
 export function getPathFromUrl(url: string) {
     if(!url) return;
     if( url ) {
-        let path    = '';
-        if(url.indexOf && url.indexOf('://') > -1) {
-            let urlTokened = url.split('://');
-            let strPath  = urlTokened[1];
-            if(strPath.indexOf && strPath.indexOf('/') > -1) {
-                path = strPath.substring(strPath.indexOf('/'));
-            } else {
-                // no "/" in url
-            }
-        } else if(url.indexOf && url.indexOf('/') > -1) {
-            // no protocol, assume first "/" to end
-            path = url.substring(url.indexOf('/'));
-        }
-        return path;
+        let oUrl        = new URL(url);
+        return oUrl.pathname;
+    }
+}
+
+export function replaceProtocol(protoStr, url: string) {
+    if(!url) return;
+    if(!protoStr) return url; 
+    if( url ) {
+        let oUrl        = new URL(url);
+        oUrl.protocol   = protoStr;
+        return oUrl.href;
+    }
+    return url;
+}
+
+export function replacePortNumber(portNumber, url: string) {
+    if(!url) return;
+    if( url ) {
+        let oUrl    = new URL(url);
+        oUrl.port   = portNumber;
+        return (oUrl.href);
+    }
+    return url
+}
+
+export function replaceHostname(hostname: string, url: string) {
+    if(!url) return;
+    if(!hostname) { return url; }
+    if(url) {
+        let oUrl = new URL(url);
+        return url.replace(oUrl.hostname, hostname);
     }
 }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -4,7 +4,7 @@ import { catchError, filter, switchMap, map, take, tap } from 'rxjs/operators';
 import { SzAdminService, SzRestConfigurationParameters, SzConfigurationService, SzServerInfo, SzMeta } from '@senzing/sdk-components-ng';
 import { HttpClient } from '@angular/common/http';
 import { SocketIoConfig } from '../common/console-config';
-import { getBasePathFromUrl, getPathFromUrl } from '../common/url-utilities';
+import { getBasePathFromUrl, getPathFromUrl, replaceHostname } from '../common/url-utilities';
 
 export interface AuthConfig {
   hostname?: string;
@@ -317,6 +317,16 @@ export class SzWebAppConfigService {
     // directly since container is immutable and
     // doesnt write to file system.
     return this.http.get<SzConsoleConfig>('./config/console').pipe(
+      map(cfg => {
+        // if url is "localhost" replace with actual "hostname" when divergent
+        if(window && window.location && window.location.hostname && window.location.hostname.length > 0 && window.location.hostname === 'localhost') {
+          let cfgUrl  = new URL(cfg.url);
+          if(window.location.hostname !== cfgUrl.hostname) {
+            cfg.url = replaceHostname(window.location.hostname, cfg.url);
+          }
+        }
+        return cfg;
+      }),
       tap(cfg => console.warn('getRuntimeConsoleConfig result: ', cfg) )
     )
   }

--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -224,13 +224,18 @@ export class SzWebAppConfigService {
         map( (cfg) => {
           if(cfg && cfg.url) {
             // check if the url has a "/path" in it
-            let _urlDomain = getBasePathFromUrl(cfg.url);
-            let _urlPath = getPathFromUrl(cfg.url);
+            let _urlDomain  = getBasePathFromUrl(cfg.url);
+            let _urlPath    = getPathFromUrl(cfg.url);
             if(_urlPath) {
               // main url should not have the "/path/to/namespace" 
               // in the options.url field
               // move it to cft.options.path as a namespace
               cfg.url = _urlDomain;
+              // if new path does not end in "socket.io"
+              // add it to the end
+              if(!_urlPath.endsWith('socket.io')) {
+                _urlPath = _urlPath + (_urlPath.endsWith('/') ? '' : '/') +'socket.io';
+              }
               cfg.options.path = _urlPath;
             }
           }


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #285 

## Why was change needed

so, turns out it still required the docker configuration to specify the `SENZING_WEB_SERVER_URL` since it would pull from that as a fallback when not specifying the `SENZING_CONSOLE_SERVER_URL`.

## What does change improve

- Changed it so that it will default to `localhost` when **_NEITHER_** variables are specified. that way if you're just doing a POC or dev work it will most likely work out of the box. You'll have to specify one(or both) for instances where it's running off it's own domain name(not on localhost) or in the cloud or on a vhost.. which if you're doing that you should expect some configuration anyways.
- Also added some better error handling while I was in there.
- Refactored url utility functions to use a better approach
