### PR TITLE
changed default console server proxy from `8273` to `8257`

### DIFF
--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -439,6 +439,7 @@ function getConsoleServerOptionsFromInput() {
     if(env.SENZING_CONSOLE_SERVER_URL) {
       retOpts.url       = env.SENZING_CONSOLE_SERVER_URL? env.SENZING_CONSOLE_SERVER_URL : retOpts.url;
       retOpts.port      = env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : getPortFromUrl(retOpts.url);
+      retOpts.port      = env.SENZING_CONSOLE_SERVER_PROXY_PORT ? env.SENZING_CONSOLE_SERVER_PROXY_PORT : retOpts.port;
       retOpts.enabled   = true;
       // set up reverse proxy
       if(retOpts.port == webServerCfg.port){
@@ -451,7 +452,7 @@ function getConsoleServerOptionsFromInput() {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
         target: replaceProtocol((getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'), env.SENZING_CONSOLE_SERVER_URL),
-        port: env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : 8257
+        port: getPortFromUrl(env.SENZING_CONSOLE_SERVER_URL) ? getPortFromUrl(env.SENZING_CONSOLE_SERVER_URL) : 8257
       }
       // change url to a "local" address
       retOpts.url = replaceProtocol(retOpts.protocol || (retOpts.proxy ? retOpts.proxy.protocol : false) || 'ws', replacePortNumber(retOpts.port, webServerCfg.url));
@@ -462,8 +463,9 @@ function getConsoleServerOptionsFromInput() {
     retOpts.port        = cmdLineOpts.webServerPortNumber ?       cmdLineOpts.webServerPortNumber   : retOpts.port;
     retOpts.port        = cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : retOpts.port;
     if(cmdLineOpts.consoleServerUrl) {
-      retOpts.url       = cmdLineOpts.consoleServerUrl ?      cmdLineOpts.consoleServerUrl : retOpts.url;
-      retOpts.port      = cmdLineOpts.consoleServerPortNumber ? cmdLineOpts.consoleServerPortNumber : getPortFromUrl(retOpts.url);
+      retOpts.url       = cmdLineOpts.consoleServerUrl ?              cmdLineOpts.consoleServerUrl : retOpts.url;
+      retOpts.port      = cmdLineOpts.consoleServerPortNumber ?       cmdLineOpts.consoleServerPortNumber : getPortFromUrl(retOpts.url);
+      retOpts.port      = cmdLineOpts.consoleServerProxyPortNumber ?  cmdLineOpts.consoleServerProxyPortNumber  : retOpts.port;
       retOpts.enabled   = true;
       if(retOpts.port == webServerCfg.port){
         // socket proxy cannot be on same port as web server

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -442,15 +442,15 @@ function getConsoleServerOptionsFromInput() {
       // set up reverse proxy
       if(retOpts.port == webServerCfg.port){
         // socket proxy cannot be on same port as web server
-        // reassign to 8273
-        retOpts.port    = 8273;
+        // reassign to 8257
+        retOpts.port    = 8257;
       }
       // and reassign url to proxy dest
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
         target: replaceProtocol((getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'https' || getProtocolFromUrl(env.SENZING_CONSOLE_SERVER_URL) === 'wss' ? 'wss':'ws'), env.SENZING_CONSOLE_SERVER_URL),
-        port: env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : 8273
+        port: env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : 8257
       }
       // change url to a "local" address
       retOpts.url = replaceProtocol(retOpts.protocol || (retOpts.proxy ? retOpts.proxy.protocol : false) || 'ws', replacePortNumber(retOpts.port, webServerCfg.url));
@@ -466,15 +466,15 @@ function getConsoleServerOptionsFromInput() {
       retOpts.enabled   = true;
       if(retOpts.port == webServerCfg.port){
         // socket proxy cannot be on same port as web server
-        // reassign to 8273
-        retOpts.port    = 8273;
+        // reassign to 8257
+        retOpts.port    = 8257;
       }
       // and reassign url to proxy dest
       retOpts.proxy = {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
         target: replaceProtocol((getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'), cmdLineOpts.consoleServerUrl),
-        port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8273
+        port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8257
       }
       // change url to a "local" address
       retOpts.url = replaceProtocol(retOpts.protocol || (retOpts.proxy ? retOpts.proxy.protocol : false) || 'ws', replacePortNumber(retOpts.port, webServerCfg.url));

--- a/run/runtime.datastore.config.js
+++ b/run/runtime.datastore.config.js
@@ -438,6 +438,7 @@ function getConsoleServerOptionsFromInput() {
     retOpts.port        = env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : retOpts.port;
     if(env.SENZING_CONSOLE_SERVER_URL) {
       retOpts.url       = env.SENZING_CONSOLE_SERVER_URL? env.SENZING_CONSOLE_SERVER_URL : retOpts.url;
+      retOpts.port      = env.SENZING_CONSOLE_SERVER_PORT ? env.SENZING_CONSOLE_SERVER_PORT : getPortFromUrl(retOpts.url);
       retOpts.enabled   = true;
       // set up reverse proxy
       if(retOpts.port == webServerCfg.port){
@@ -462,7 +463,7 @@ function getConsoleServerOptionsFromInput() {
     retOpts.port        = cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : retOpts.port;
     if(cmdLineOpts.consoleServerUrl) {
       retOpts.url       = cmdLineOpts.consoleServerUrl ?      cmdLineOpts.consoleServerUrl : retOpts.url;
-      retOpts.port      = getPortFromUrl(retOpts.url);
+      retOpts.port      = cmdLineOpts.consoleServerPortNumber ? cmdLineOpts.consoleServerPortNumber : getPortFromUrl(retOpts.url);
       retOpts.enabled   = true;
       if(retOpts.port == webServerCfg.port){
         // socket proxy cannot be on same port as web server
@@ -474,7 +475,7 @@ function getConsoleServerOptionsFromInput() {
         protocol: (getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'),
         hostname: webServerCfg.hostname ? webServerCfg.hostname : 'localhost',
         target: replaceProtocol((getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'https' || getProtocolFromUrl(cmdLineOpts.consoleServerUrl) === 'wss' ? 'wss':'ws'), cmdLineOpts.consoleServerUrl),
-        port: cmdLineOpts.consoleServerPortNumber ?   cmdLineOpts.consoleServerPortNumber  : 8257
+        port: getPortFromUrl(cmdLineOpts.consoleServerUrl) ? getPortFromUrl(cmdLineOpts.consoleServerUrl) : 8257
       }
       // change url to a "local" address
       retOpts.url = replaceProtocol(retOpts.protocol || (retOpts.proxy ? retOpts.proxy.protocol : false) || 'ws', replacePortNumber(retOpts.port, webServerCfg.url));

--- a/run/webserver/index.js
+++ b/run/webserver/index.js
@@ -439,8 +439,8 @@ if(consoleOptions && consoleOptions.enabled) {
         console_proxy.on('error', (err) => {
           console.log('[error] WS Console Reverse Proxy Server: ', err);
         });
-        console_proxy.listen(consoleOptions.port || 8273, () => {
-          console.log(`[started] WS Console Reverse Proxy Server started on port ${(consoleOptions.port || 8273)}. Forwarding to ${consoleOptions.proxy.target} :)`);
+        console_proxy.listen(consoleOptions.port || 8257, () => {
+          console.log(`[started] WS Console Reverse Proxy Server started on port ${(consoleOptions.port || 8257)}. Forwarding to ${consoleOptions.proxy.target} :)`);
           resolve();
         });
       } else {

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,7 @@
   <title>Entity Search</title>
   <base href="/">
   <meta http-equiv="Content-Security-Policy" content="default-src 'self';
-  connect-src 'self' wss://localhost:8255 ws://localhost:8255 ws://localhost:8273 ws://americium.local:8273;
+  connect-src 'self' wss://localhost:8255 ws://localhost:8255 ws://localhost:8257 ws://americium.local:8257;
   script-src 'self' 'unsafe-eval' 'unsafe-inline';
   img-src 'self' data:;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #289 

## Why was change needed

changed default console server proxy from `8273` to `8257`

## What does change improve

conforms with our default port ranges( `8250-8265` )
