### PR TITLE
#291

### DIFF
--- a/src/app/services/config.service.ts
+++ b/src/app/services/config.service.ts
@@ -216,6 +216,15 @@ export class SzWebAppConfigService {
         }),
         take(1)
       ).subscribe(onStreamConfigResponse);
+    });
+
+    // we need to update the runtime console config on server info update
+    this.onServerInfoUpdated.pipe(
+      filter((srvInfo: undefined | SzServerInfo) => {
+        return srvInfo !== undefined && this.isAdminEnabled;
+      }),
+      take(1)
+    ).subscribe((result) => {
       this.getRuntimeConsoleConfig().pipe(
         filter(() => {
           return this.isAdminEnabled;
@@ -239,7 +248,7 @@ export class SzWebAppConfigService {
               cfg.options.path = _urlPath;
             }
           }
-
+  
           return cfg
         })
       ).subscribe(onConsoleConfigResponse)


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

resolves #291 

## Why was change needed

to enable integrated console for `senzing-api-server`. there was conditional logic that was never getting called when running against an instance of the api server but was running correctly when running against the poc server.

## What does change improve

docker formation compatibility